### PR TITLE
Add PyPi publishing workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      uses: BSFishy/pip-action@v1
+      with:
+        packages: |
+          twine
+          build
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        pyproject-build
+        twine upload dist/*


### PR DESCRIPTION
This PR adds a workflow that automatically publishes pushed tags `v*` to PyPi.

> [!IMPORTANT]
> You need to generate a PyPi token and add it as a secret called `PYPI_TOKEN` to the repo or organisation. If you add it to the org, make sure to expose it to this repo.

After that, creating and pushing a new tag will release the current state.