### PR TITLE
Add alias scripts for converting to formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Run converter with command (both in Linux and in Windows):
 
 Also you can pass both formats to convert .frd to .vtk and .vtu at once.
 
+There are also the following aliases for converting files to a fixed format
+
+    ccxToVTK yourjobname.frd
+    ccxToVTU yourjobname.frd
+
 It is recommended to convert .frd to modern XML .vtu format - its contents are compressed. If you have more than one time step there will be additional XML file created - [the PVD file](https://www.paraview.org/Wiki/ParaView/Data_formats#PVD_File_Format). Open it in Paraview to read data from all time steps (all VTU files) at ones.
 
 Starting from ccx2paraview v3.0.0 legacy .vtk format is also fully supported - previously there were problems with component names.

--- a/ccx2paraview/cli.py
+++ b/ccx2paraview/cli.py
@@ -23,21 +23,23 @@ def clean_screen():
     os.system('cls' if os.name=='nt' else 'clear')
 
 
+def filename_type(filename):
+    if not os.path.isfile(filename):
+        raise argparse.ArgumentTypeError("The given file doesn't exist.")
+    if not os.path.splitext(filename)[1].lower() == ".frd":
+        raise argparse.ArgumentTypeError("The given file isn't a .frd file.")
+    return filename
+
+
 def main():
     # Configure logging
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
     # Command line arguments
     ap = argparse.ArgumentParser()
-    ap.add_argument('filename', type=str, help='FRD file name with extension')
-    ap.add_argument('format', type=str, nargs='+', help='output format: vtk, vtu')
+    ap.add_argument('filename', type=filename_type, help='FRD file name with extension')
+    ap.add_argument('format', type=str, nargs='+', help='Output format', choices=['vtk', 'vtu'])
     args = ap.parse_args()
-
-    # Check arguments
-    assert os.path.isfile(args.filename), 'FRD file does not exist.'
-    for a in args.format:
-        msg = 'Wrong format "{}". '.format(a) + 'Choose between: vtk, vtu.'
-        assert a in ('vtk', 'vtu'), msg
 
     # Create converter and run it
     ccx2paraview = Converter(args.filename, args.format)

--- a/ccx2paraview/cli.py
+++ b/ccx2paraview/cli.py
@@ -46,6 +46,28 @@ def main():
     ccx2paraview.run()
 
 
+def main_with_format(format):
+    # Configure logging
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+    # Command line arguments
+    ap = argparse.ArgumentParser()
+    ap.add_argument('filename', type=filename_type, help='FRD file name with extension')
+    args = ap.parse_args()
+
+    # Create converter and run it
+    ccx2paraview = Converter(args.filename, [format])
+    ccx2paraview.run()
+
+
+def ccx_to_vtk():
+    main_with_format("vtk")
+
+
+def ccx_to_vtu():
+    main_with_format("vtu")
+
+
 #if __name__ == '__main__':
 #    clean_screen()
 #    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ Repository = "https://github.com/calculix/ccx2paraview"
 
 [project.scripts]
 ccx2paraview = "ccx2paraview.cli:main"
+ccxToVTK = "ccx2paraview.cli:ccx_to_vtk"
+ccxToVTU = "ccx2paraview.cli:ccx_to_vtu"
 
 [tool.setuptools-git-versioning]
 enabled = true


### PR DESCRIPTION
This PR adds alias scripts to directly convert an input file to `vtk` or `vtu`.

I followed the naming scheme of converter provided by OpenFOAM, which is called `foamToVTK`.
The added executables are `ccxToVTK` and `ccxToVTU`.

I also modernised the argparse a bit to directly check arguments in the parser.
