### PR TITLE
make the development version installable by pip

### DIFF
--- a/ccx2paraview/__init__.py
+++ b/ccx2paraview/__init__.py
@@ -1,0 +1,1 @@
+from . import common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ ccxToVTU = "ccx2paraview.cli:ccx_to_vtu"
 
 [tool.setuptools-git-versioning]
 enabled = true
+
+[tool.setuptools]
+include-package-data = true
+packages = ["ccx2paraview"]


### PR DESCRIPTION
I had a hard time figuring out how to install and use the package...

So updated pyproject.toml and added \_\_init__.py so that the development version is installable by pip: 
`python -m pip install git+https://github.com/soylentOrange/ccx2paraview.git@make-pip-work-for-devel`

or, once it's merged: 
`python -m pip install git+https://github.com/calculix/ccx2paraview.git`

Usage is then identical to the description in the README.md

Run converter with command (tested successfully on mac):
```
ccx2paraview yourjobname.frd vtk
ccx2paraview yourjobname.frd vtu

ccxToVTK yourjobname.frd
ccxToVTU yourjobname.frd
```

Use converter in python (tested successfully on mac):
```
import logging
import ccx2paraview.common
logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
c = ccx2paraview.common.Converter(frd_file_name, ['vtu'])
c.run()
```