### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name="ccx2paraview"
 dynamic = [ "version" ]
 dependencies = [
-    "vtk", "numpy"
+    "numpy"
 ]
 requires-python = ">=3.8"
 authors = [


### PR DESCRIPTION
There seems to be an incompability between paraview and vtk, see: https://github.com/conda-forge/ccx2paraview-feedstock/issues/9

With vtk listed as dependency in pyproject.toml, ccx2paraview installs fine and converts frd-files as expected but breaks ParaView's pvpython.

I removed vtk from the dependencies in pyproject.toml. 

Just make sure that vtk is available either directly or from conda's paraview package before installing ccx2paraview.

To install the updated version with vtk:
```
conda create -n ccx2paraview_vtk vtk
conda activate ccx2paraview_vtk
python -m pip install git+https://github.com/soylentOrange/ccx2paraview.git@vtk-paraview-incompability
```
or with ParaView:
```
conda create -n ccx2paraview_paraview paraview
conda activate ccx2paraview_paraview
python -m pip install git+https://github.com/soylentOrange/ccx2paraview.git@vtk-paraview-incompability
```
Once it's merged, you can install it via:
```
# still, you need to have either vtk or paraview installed beforehand...
python -m pip install git+https://github.com/calculix/ccx2paraview.git
```