### PR TITLE
Fix syntax warning invalid escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__/
 /pypi/
 /build/
 /dist/
-/tests/sim-frds
-/tests/test-logs
-/tests/test-vtus
+/tests/sim_frds
+/tests/test_logs
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 /pypi/
 /build/
 /dist/
-/test/sim-frds
-/test/test-logs
-/test/test-vtus
+/tests/sim-frds
+/tests/test-logs
+/tests/test-vtus
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ __pycache__/
 /pypi/
 /build/
 /dist/
+/test/sim-frds
+/test/test-logs
+/test/test-vtus
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To install and run the latest release (version 3.1.0) of of this converter you'l
     # or
     pipx install ccx2paraview
     # or 
-    conda create -n ccx2paraview_rel numpy conda-forge::ccx2paraview conda-forge::ccx2paraview
+    conda create -n ccx2paraview_rel numpy conda-forge::paraview conda-forge::ccx2paraview
 
 ### Usage 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To install and run the latest release (version 3.1.0) of of this converter you'l
     # or, within a new conda environment: 
     conda create -n ccx2paraview_rel numpy paraview ccx2paraview
 
-Installing paraview and ccx2paraview from the conda-forge channel can be achieved by adding conda-forge to your channels with:
+**Hint!** Installing paraview and ccx2paraview from the conda-forge channel can be achieved by adding conda-forge to your channels with:
 
     conda config --add channels conda-forge
     conda config --set channel_priority strict

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ FRD reader is tested to reduce processing time as much as possible. Now it's qui
 To install and run the latest release (version 3.1.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/) or [conda](https://docs.anaconda.com/miniconda/miniconda-install/): 
 
     pip install ccx2paraview
-    # or
+    # or, with pipx:
     pipx install ccx2paraview
-    # or 
-    conda create -n ccx2paraview_rel numpy conda-forge::paraview conda-forge::ccx2paraview
+    # or, within a new conda environment: 
+    conda create -n ccx2paraview_rel numpy paraview ccx2paraview
+
+Installing paraview and ccx2paraview from the conda-forge channel can be achieved by adding conda-forge to your channels with:
+
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
 
 ### Usage 
 
@@ -107,13 +112,13 @@ Using a conda-environment:
 * Python 3.12: works!
 
 ```
-conda create -n ccx2paraview_rel python=3.12 numpy conda-forge::paraview conda-forge::ccx2paraview
+conda create -n ccx2paraview_rel python=3.12 numpy paraview ccx2paraview
 ```
 
 * Python 3.13: works - but will provoke SyntaxWarning: invalid escape sequence
 
 ```
-conda create -n ccx2paraview_rel numpy conda-forge::paraview conda-forge::ccx2paraview
+conda create -n ccx2paraview_rel numpy paraview ccx2paraview
 ```
 
 
@@ -168,7 +173,7 @@ To install this converter from github you'll need [Python 3](https://www.python.
     pip install git+https://github.com/calculix/ccx2paraview.git
 
     # or, with conda (paraview has vtk, so no need to install it seprately):
-    conda create -n ccx2paraview_devel python=3.12 numpy conda-forge::paraview
+    conda create -n ccx2paraview_devel python=3.12 numpy paraview
     conda activate ccx2paraview_devel
     pip install git+https://github.com/calculix/ccx2paraview.git
 
@@ -194,9 +199,9 @@ To use the development version of ccx2paraview in your python code:
 
 ```Python
 import logging
-import ccx2paraview.common
+from ccx2paraview.common import Converter
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
-c = ccx2paraview.common.Converter(frd_file_name, ['vtu'])
+c = Converter(frd_file_name, ['vtu'])
 c.run()
 ```
 

--- a/ccx2paraview/__init__.py
+++ b/ccx2paraview/__init__.py
@@ -1,1 +1,4 @@
+"""Make ccx2paraview a regular package."""
+
 from . import common
+from .common import Converter

--- a/ccx2paraview/__main__.py
+++ b/ccx2paraview/__main__.py
@@ -1,3 +1,5 @@
+"""For nuitka build..."""
+
 from . import cli
 
 cli.clean_screen()

--- a/ccx2paraview/cli.py
+++ b/ccx2paraview/cli.py
@@ -10,13 +10,13 @@ analysis results in Paraview. Generates Mises and
 Principal components for stress and strain tensors.
 """
 
-from .common import Converter
-
 # Standard imports
 import argparse
 import logging
 import os
 
+# local import
+from .common import Converter
 
 def clean_screen():
     """Clean screen."""
@@ -24,6 +24,7 @@ def clean_screen():
 
 
 def filename_type(filename):
+    """Check for frd-extension."""
     if not os.path.isfile(filename):
         raise argparse.ArgumentTypeError("The given file doesn't exist.")
     if not os.path.splitext(filename)[1].lower() == ".frd":
@@ -32,6 +33,7 @@ def filename_type(filename):
 
 
 def main():
+    """Create and run a converter."""
     # Configure logging
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
@@ -46,7 +48,8 @@ def main():
     ccx2paraview.run()
 
 
-def main_with_format(format):
+def main_with_format(output_format):
+    """Create and run a converter with fixed format."""
     # Configure logging
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
@@ -56,15 +59,17 @@ def main_with_format(format):
     args = ap.parse_args()
 
     # Create converter and run it
-    ccx2paraview = Converter(args.filename, [format])
+    ccx2paraview = Converter(args.filename, [output_format])
     ccx2paraview.run()
 
 
 def ccx_to_vtk():
+    """Create and run a converter with vtk format."""
     main_with_format("vtk")
 
 
 def ccx_to_vtu():
+    """Create and run a converter with vtu format."""
     main_with_format("vtu")
 
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -39,7 +39,7 @@ def write_converted_file(file_name, ugrid):
     writer.Write()
 
 
-"""Classes and functions for reading CalculiX .frd files."""
+# Classes and functions for reading CalculiX .frd files.
 
 
 class NodalPointCoordinateBlock:
@@ -73,38 +73,37 @@ class NodalPointCoordinateBlock:
             new_node_number += 1
 
         self.numnod = self.points.GetNumberOfPoints() # number of nodes in this block
-        logging.info('{} nodes'.format(self.numnod)) # total number of nodes
+        logging.info('%d nodes', self.numnod) # total number of nodes
 
     def get_node_numbers(self):
         global renumbered_nodes
         return sorted(renumbered_nodes.keys())
 
 
-"""NOTE Not used
-class NodalPointCoordinateBlock2:
-    # Nodal Point Coordinate Block: cgx_2.20.pdf Manual, § 11.3.
-    # self.nodes is a Pandas DataFrame.
+# NOTE Not used
+# class NodalPointCoordinateBlock2:
+#     # Nodal Point Coordinate Block: cgx_2.20.pdf Manual, § 11.3.
+#     # self.nodes is a Pandas DataFrame.
 
-    def __init__(self, in_file):
-        import pandas
-        lines = ''
-        while True:
-            line = in_file.readline()
-            if not line or line.strip() == '-3': break
-            lines += line
+#     def __init__(self, in_file):
+#         import pandas
+#         lines = ''
+#         while True:
+#             line = in_file.readline()
+#             if not line or line.strip() == '-3': break
+#             lines += line
 
-        from io import StringIO
-        self.nodes = pandas.read_fwf(StringIO(lines), usecols=[1,2,3,4], index_col=0,
-            names=['skip', 'node', 'X', 'Y', 'Z'], widths=[5, 8, 12, 12, 12])
+#         from io import StringIO
+#         self.nodes = pandas.read_fwf(StringIO(lines), usecols=[1,2,3,4], index_col=0,
+#             names=['skip', 'node', 'X', 'Y', 'Z'], widths=[5, 8, 12, 12, 12])
 
-        self.numnod = self.nodes.shape[0] # number of nodes in this block
-        logging.info('{} nodes'.format(self.numnod)) # total number of nodes
+#         self.numnod = self.nodes.shape[0] # number of nodes in this block
+#         logging.info('{} nodes'.format(self.numnod)) # total number of nodes
 
-    def get_node_numbers(self):
-        # Dataframe index column.
-        # return [int(n) for n in list(self.nodes.index.values)]
-        return list(self.nodes.index.values)
-"""
+#     def get_node_numbers(self):
+#         # Dataframe index column.
+#         # return [int(n) for n in list(self.nodes.index.values)]
+#         return list(self.nodes.index.values)
 
 
 def convert_elem_type(frd_elem_type):
@@ -305,10 +304,9 @@ def get_element_connectivity(e_type, e_nodes):
 
     # frd: 15 node penta element
     elif e_type==5 or e_type==2:
-        """CalculiX elements type 5 are not supported in VTK and
-        has to be processed as CalculiX type 2 (6 node wedge,
-        VTK type 13). Additional nodes are omitted.
-        """
+        # CalculiX elements type 5 are not supported in VTK and
+        # has to be processed as CalculiX type 2 (6 node wedge,
+        # VTK type 13). Additional nodes are omitted.
         for i in [0,2,1,3,5,4]: # repositioning nodes
             connectivity.append(e_nodes[i]) # nodes after renumbering
 
@@ -341,7 +339,7 @@ class ElementDefinitionBlock:
             self.read_element(line)
 
         self.numelem = self.cells.GetNumberOfCells() # number of elements in this block
-        logging.info('{} cells'.format(self.numelem)) # total number of elements
+        logging.info('%d cells', self.numelem) # total number of elements
 
     def read_element(self, line):
         """Read element composition
@@ -355,7 +353,7 @@ class ElementDefinitionBlock:
         -2        10        12        11
         """
         global renumbered_nodes
-        element_num = int(line.split()[1])
+        # element_num = int(line.split()[1])
         element_type = int(line.split()[2])
         element_nodes = []
         for j in range(self.num_lines(element_type)):
@@ -380,44 +378,43 @@ class ElementDefinitionBlock:
         return (0, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1)[etype]
 
 
-"""NOTE Not used
-class ElementDefinitionBlock2:
-    # Element Definition Block: cgx_2.20.pdf Manual, § 11.4.
-    # self.elements is a Pandas DataFrame.
+# NOTE Not used
+# class ElementDefinitionBlock2:
+#     # Element Definition Block: cgx_2.20.pdf Manual, § 11.4.
+#     # self.elements is a Pandas DataFrame.
 
-    def __init__(self, in_file):
-        # Read element composition
-        # -1      2355    1    0    1
-        # -2     20814     26109     21063     25605     20816     26111     21065     25607
-        # -1      2356    1    0    1
-        # -2     20781     25602     21066     26106     20783     25604     21068     26108
-        # -1         1    1    0AIR
-        # -2         1         2         3         4         5         6         7         8
-        # -1         1   10    0    1
-        # -2         1         2         3         4         5         6         7         8
-        # -1         2   11    0    2
-        # -2         9        10
-        # -1         3   12    0    2
-        # -2        10        12        11
-        import pandas
-        lines = ''
-        while True:
-            line = in_file.readline().lstrip()
-            if not line or line.rstrip() == '-3': break
-            if line.startswith('-1'):
-                line = line[:19]
-            lines += line[3:]
+#     def __init__(self, in_file):
+#         # Read element composition
+#         # -1      2355    1    0    1
+#         # -2     20814     26109     21063     25605     20816     26111     21065     25607
+#         # -1      2356    1    0    1
+#         # -2     20781     25602     21066     26106     20783     25604     21068     26108
+#         # -1         1    1    0AIR
+#         # -2         1         2         3         4         5         6         7         8
+#         # -1         1   10    0    1
+#         # -2         1         2         3         4         5         6         7         8
+#         # -1         2   11    0    2
+#         # -2         9        10
+#         # -1         3   12    0    2
+#         # -2        10        12        11
+#         import pandas
+#         lines = ''
+#         while True:
+#             line = in_file.readline().lstrip()
+#             if not line or line.rstrip() == '-3': break
+#             if line.startswith('-1'):
+#                 line = line[:19]
+#             lines += line[3:]
 
-        # for line in lines.split('\n')[:5]:
-        #     logging.debug(line)
+#         # for line in lines.split('\n')[:5]:
+#         #     logging.debug(line)
 
-        from io import StringIO
-        self.elements = pandas.read_fwf(StringIO(lines), index_col=0, header=None)
-        # logging.debug(self.elements.head())
+#         from io import StringIO
+#         self.elements = pandas.read_fwf(StringIO(lines), index_col=0, header=None)
+#         # logging.debug(self.elements.head())
 
-        self.numelem = self.elements.shape[0] # number of elements in this block
-        logging.info('{} cells'.format(self.numelem)) # total number of elements
-    """
+#         self.numelem = self.elements.shape[0] # number of elements in this block
+#         logging.info('{} cells'.format(self.numelem)) # total number of elements
 
 
 class NodalResultsBlock:
@@ -435,6 +432,7 @@ class NodalResultsBlock:
         self.txt = ''
 
     def run(self, in_file, node_block):
+        """Run the converter."""
         self.in_file = in_file
         self.node_block = node_block
 
@@ -451,7 +449,7 @@ class NodalResultsBlock:
         -4  DOR1  Rx    4    1
         """
         line = self.in_file.readline().strip()
-        regex = '^-4\s+(\w+)' + '\D+(\d+)'*2
+        regex = r'^-4\s+(\w+)' + r'\D+(\d+)'*2
         match = match_line(regex, line)
         self.ncomps = int(match.group(2)) # amount of components
 
@@ -495,7 +493,7 @@ class NodalResultsBlock:
         """
         for i in range(self.ncomps):
             line = self.in_file.readline()[5:]
-            regex = '^\w+'
+            regex = r'^\w+'
             match = match_line(regex, line)
 
             # Exclude variable name from the component name: SXX->XX, EYZ->YZ
@@ -537,7 +535,7 @@ class NodalResultsBlock:
                 break
 
             row_comps = min(6, self.ncomps) # amount of values written in row
-            regex = '^-1\s+(\d+)' + '(.{12})' * row_comps
+            regex = r'^-1\s+(\d+)' + '(.{12})' * row_comps
             match = match_line(regex, line)
             node = int(match.group(1))
             data = []
@@ -548,7 +546,7 @@ class NodalResultsBlock:
                     num = float(m)
                     if ('NaN' in m or 'Inf' in m):
                         emitted_warning_types['NaNInf'] += 1
-                except:
+                except ValueError:
                     # Too big number is written without 'E'
                     num = float(re.sub(r'(.+).([+-])(\d{3})', r'\1e\2\3', m))
                     emitted_warning_types['WrongFormat'] += 1
@@ -563,7 +561,7 @@ class NodalResultsBlock:
             for j in range((self.ncomps-1)//6):
                 row_comps = min(6, self.ncomps-6*(j+1)) # amount of values written in row
                 line = self.in_file.readline().strip()
-                regex = '^-2\s+' + '(.{12})' * row_comps
+                regex = r'^-2\s+' + '(.{12})' * row_comps
                 match = match_line(regex, line)
                 data = [float(match.group(c+1)) for c in range(row_comps)]
                 self.results[node].extend(data)
@@ -707,17 +705,21 @@ class FRD:
         # Iterate over nodes
         for node_num in b.node_block.get_node_numbers():
             data = b.results[node_num] # list with results for current node
-            Sxx = data[0]; Syy = data[1]; Szz = data[2]
-            Sxy = data[3]; Syz = data[4]; Sxz = data[5]
+            s_xx = data[0]
+            s_yy = data[1]
+            s_zz = data[2]
+            s_xy = data[3]
+            s_yz = data[4]
+            s_xz = data[5]
 
             # Calculate Mises stress for current node
             mises = 1 / math.sqrt(2) \
-                * math.sqrt((Sxx - Syy)**2 \
-                + (Syy - Szz)**2 \
-                + (Szz - Sxx)**2 \
-                + 6 * Syz**2 \
-                + 6 * Sxz**2 \
-                + 6 * Sxy**2)
+                * math.sqrt((s_xx - s_yy)**2 \
+                + (s_yy - s_zz)**2 \
+                + (s_zz - s_xx)**2 \
+                + 6 * s_yz**2 \
+                + 6 * s_xz**2 \
+                + 6 * s_xy**2)
             b1.results[node_num] = [mises]
 
         b1.get_some_log()
@@ -735,17 +737,21 @@ class FRD:
         # Iterate over nodes
         for node_num in b.node_block.get_node_numbers():
             data = b.results[node_num] # list with results for current node
-            Sxx = data[0]; Syy = data[1]; Szz = data[2]
-            Sxy = data[3]; Syz = data[4]; Sxz = data[5]
+            s_xx = data[0]
+            s_yy = data[1]
+            s_zz = data[2]
+            s_xy = data[3]
+            s_yz = data[4]
+            s_xz = data[5]
 
             # Calculate Mises stress for current node
             mises = 1 / math.sqrt(2) \
-                * math.sqrt((Sxx - Syy)**2 \
-                + (Syy - Szz)**2 \
-                + (Szz - Sxx)**2 \
-                + 6 * Syz**2 \
-                + 6 * Sxz**2 \
-                + 6 * Sxy**2)
+                * math.sqrt((s_xx - s_yy)**2 \
+                + (s_yy - s_zz)**2 \
+                + (s_zz - s_xx)**2 \
+                + 6 * s_yz**2 \
+                + 6 * s_xz**2 \
+                + 6 * s_xy**2)
             b1.results[node_num] = [mises]
 
         b1.get_some_log()
@@ -763,9 +769,13 @@ class FRD:
         # Iterate over nodes
         for node_num in b.node_block.get_node_numbers():
             data = b.results[node_num] # list with results for current node
-            Txx = data[0]; Tyy = data[1]; Tzz = data[2]
-            Txy = data[3]; Tyz = data[4]; Txz = data[5]
-            tensor = np.array([[Txx, Txy, Txz], [Txy, Tyy, Tyz], [Txz, Tyz, Tzz]])
+            t_xx = data[0]
+            t_yy = data[1]
+            t_zz = data[2]
+            t_xy = data[3]
+            t_yz = data[4]
+            t_xz = data[5]
+            tensor = np.array([[t_xx, t_xy, t_xz], [t_xy, t_yy, t_yz], [t_xz, t_yz, t_zz]])
 
             # Calculate principal values for current node
             eigenvalues = sorted(np.linalg.eigvals(tensor).tolist())
@@ -794,7 +804,7 @@ def get_inc_step(line):
     CL  102 117547.9305          90                     2    2MODAL      1
     """
     line = line[12:]
-    regex = '^(.{12})\s+\d+\s+\d+\s+(\d+)'
+    regex = r'^(.{12})\s+\d+\s+\d+\s+(\d+)'
     match = match_line(regex, line)
     inc = float(match.group(1)) # could be frequency, time or any numerical value
     step = int(match.group(2)) # step number
@@ -818,7 +828,7 @@ def match_line(regex, line):
 
 
 
-"""Main class and functions."""
+# Main class and functions.
 
 
 def convert_frd_data_to_vtk(b, node_block):
@@ -885,15 +895,15 @@ class Converter:
         if not self.frd.has_mesh():
             return
 
-        """For each time increment generate separate .vt* file.
-        Output file name will be the same as input but with serial number.
+        # For each time increment generate separate .vt* file.
+        # Output file name will be the same as input but with serial number.
 
-        Threads are used to save .vt* files:
-        ccx2paraview_0 - no threading at all         7m 37.5s    25m 33.7s
-        ccx2paraview_1 - save files with threading   7m 44.0s    25m 32.8s
-        ccx2paraview_2 - slight refactoring of 0     7m 18.0s    26m 10.2s
-        ccx2paraview_3 - slight refactoring of 1     7m 25.4s    25m 1.1s
-        """
+        # Threads are used to save .vt* files:
+        # ccx2paraview_0 - no threading at all         7m 37.5s    25m 33.7s
+        # ccx2paraview_1 - save files with threading   7m 44.0s    25m 32.8s
+        # ccx2paraview_2 - slight refactoring of 0     7m 18.0s    26m 10.2s
+        # ccx2paraview_3 - slight refactoring of 1     7m 25.4s    25m 1.1s
+
         self.frd.count_increments()
         for step, inc, num in self.step_inc_num(): # NOTE Could be (0, 0, '')
             result_blocks = self.frd.parse_results(step, inc) # NOTE Could be empty list []
@@ -909,7 +919,7 @@ class Converter:
                     pd.Modified()
 
             for t in threads:
-                t.join() # do not start a new thread while and old one is running 
+                t.join() # do not start a new thread while and old one is running
             threads.clear()
             for fmt in self.fmt_list: # ['.vtk', '.vtu']
                 file_name = self.frd_file_name[:-4] + num + fmt
@@ -925,7 +935,7 @@ class Converter:
 
         in_file.close()
         for t in threads:
-            t.join() # do not start a new thread while and old one is running 
+            t.join() # do not start a new thread while and old one is running
 
     def step_inc_num(self):
         """If model has many time increments - many output files

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -903,7 +903,7 @@ class Converter:
     def run(self):
         """Run the Converter."""
         threads = [] # list of Threads
-        logging.info('Reading: %s', os.path.basename(self.frd_file_name))
+        logging.info('Reading %s', os.path.basename(self.frd_file_name))
         in_file = open(self.frd_file_name, 'r', encoding = self.encoding)
         # pylint: disable-next=attribute-defined-outside-init
         self.frd = FRD(in_file)
@@ -941,7 +941,7 @@ class Converter:
             threads.clear()
             for fmt in self.fmt_list: # ['.vtk', '.vtu']
                 file_name = self.frd_file_name[:-4] + num + fmt
-                logging.info('Writing: %s', os.path.basename(file_name))
+                logging.info('Writing %s', os.path.basename(file_name))
                 t = threading.Thread(target=write_converted_file,
                     args=(file_name, self.frd.ugrid))
                 t.start()

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -895,7 +895,7 @@ class Converter:
 
     # TODO Merge with FRD class
 
-    def __init__(self, frd_file_name, fmt_list, encoding: str | None = None):
+    def __init__(self, frd_file_name, fmt_list, encoding:str=None):
         self.frd_file_name = frd_file_name
         self.fmt_list = ['.' + fmt.lower() for fmt in fmt_list] # ['.vtk', '.vtu']
         self.encoding = encoding
@@ -980,12 +980,10 @@ class Converter:
             f.write('<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">\n')
             f.write('\t<Collection>\n')
 
-            # TODO: check if "step" is required here:
-            # was: for step, inc, num in self.step_inc_num():
-            for inc, num in self.step_inc_num():
+            for step, inc, num in self.step_inc_num():
                 file_name = os.path.basename(self.frd_file_name[:-4]) + num
                 file_name = os.path.basename(file_name)
-                f.write(f'\t\t<DataSet file="{file_name}vtu" timestep="{inc}"/>\n')
+                f.write(f'\t\t<DataSet file="{file_name}.vtu" timestep="{inc}"/>\n')
 
             f.write('\t</Collection>\n')
             f.write('</VTKFile>')

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -43,7 +43,7 @@ def write_converted_file(file_name, ugrid):
 
 # Classes and functions for reading CalculiX .frd files.
 
-
+# pylint: disable-next=too-few-public-methods
 class NodalPointCoordinateBlock:
     """Nodal Point Coordinate Block: cgx_2.20.pdf Manual, § 11.3.
     Generate vtkPoints. Points should be renumbered starting from 0.
@@ -285,11 +285,9 @@ def convert_elem_type(frd_elem_type):
         'MASS':1}
     if frd_elem_type in frd2vtk_num:
         return frd2vtk_num[frd_elem_type]
-    else:
-        if frd_elem_type in frd2vtk_txt:
-            return frd2vtk_txt[frd_elem_type]
-        else:
-            return 0
+    if frd_elem_type in frd2vtk_txt:
+        return frd2vtk_txt[frd_elem_type]
+    return 0
 
 
 def get_element_connectivity(e_type, e_nodes):
@@ -309,7 +307,7 @@ def get_element_connectivity(e_type, e_nodes):
             connectivity.append(e_nodes[i]) # nodes after renumbering
 
     # frd: 15 node penta element
-    elif e_type==5 or e_type==2:
+    elif e_type in (5,2):
         # CalculiX elements type 5 are not supported in VTK and
         # has to be processed as CalculiX type 2 (6 node wedge,
         # VTK type 13). Additional nodes are omitted.
@@ -427,7 +425,7 @@ class ElementDefinitionBlock:
 #         self.numelem = self.elements.shape[0] # number of elements in this block
 #         logging.info('{} cells'.format(self.numelem)) # total number of elements
 
-
+# pylint: disable-next=too-many-instance-attributes
 class NodalResultsBlock:
     """Nodal Results Block: cgx_2.20.pdf Manual, § 11.6."""
 
@@ -522,6 +520,7 @@ class NodalResultsBlock:
             else:
                 self.components.append(component_name)
 
+    # pylint: disable-next=too-many-locals
     def read_nodal_results(self):
         """Iterate over nodal results
         -1         1-7.97316E+10-3.75220E-01
@@ -636,7 +635,7 @@ class FRD:
                 break
 
             # End
-            elif key == '9999':
+            if key == '9999':
                 break
 
         if self.node_block.numnod:
@@ -807,7 +806,7 @@ class FRD:
     def has_mesh(self):
         """Check if the file might be empty."""
         blocks = [self.node_block, self.elem_block]
-        if all([b is not None for b in blocks]):
+        if all(b is not None for b in blocks):
             return True
         logging.warning('File is empty!')
         return False
@@ -837,9 +836,8 @@ def match_line(regex, line):
     match = re.search(regex, line)
     if match:
         return match
-    else:
-        logging.error("Can\'t parse line:\n%s\nwith regex:\n%s", line, regex)
-        raise SyntaxError(f"Can\'t parse line:\n{line}\nwith regex:\n{regex}")
+    logging.error("Can\'t parse line:\n%s\nwith regex:\n%s", line, regex)
+    raise SyntaxError(f"Can\'t parse line:\n{line}\nwith regex:\n{regex}")
 
 
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -980,7 +980,7 @@ class Converter:
             f.write('<VTKFile type="Collection" version="0.1" byte_order="LittleEndian">\n')
             f.write('\t<Collection>\n')
 
-            for step, inc, num in self.step_inc_num():
+            for _, inc, num in self.step_inc_num():
                 file_name = os.path.basename(self.frd_file_name[:-4]) + num
                 file_name = os.path.basename(file_name)
                 f.write(f'\t\t<DataSet file="{file_name}.vtu" timestep="{inc}"/>\n')

--- a/tests/ccx2paraview_simulate_and_test.yaml
+++ b/tests/ccx2paraview_simulate_and_test.yaml
@@ -1,0 +1,10 @@
+name: ccx2paraview_simulate_and_test
+channels: 
+  - conda-forge
+dependencies:
+  - python 
+  - pip
+  - calculix
+  - numpy
+  - paraview
+  - scipy

--- a/tests/simulate_and_test.py
+++ b/tests/simulate_and_test.py
@@ -6,7 +6,12 @@ Solve Calculix examples using pygccx first...
 then test ccx2paraview converter on the CalculiX examples' frd-output
 
 Setup of the conda environment is handled by conda wingman extension: 
+(You need to open the ccx2paraview_simulate_and_test.yaml in ./tests)
 Show and Run Commands > Conda Wingman: Build Conda Environment from YAML file
+Show and Run Commands > Conda Wingman: Activate Conda Environment from YAML file
+
+Set the Python Interpreter for VS Code to the environment's one:
+Show and Run Commands > Python: Select Interpreter
 
 Ctrl+F5 to run in VSCode. 
 """

--- a/tests/simulate_and_test.py
+++ b/tests/simulate_and_test.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Solve Calculix examples using pygccx first...
+then test ccx2paraview converter on the CalculiX examples' frd-output
+
+Setup of the conda environment is handled by conda wingman extension: 
+Show and Run Commands > Conda Wingman: Build Conda Environment from YAML file
+
+Ctrl+F5 to run in VSCode. 
+"""
+
+# Standard imports
+import os
+import sys
+import time
+import shutil
+import logging
+import subprocess
+
+sys_path = os.path.abspath(__file__)
+sys_path = os.path.dirname(sys_path)
+sys_path = os.path.join(sys_path, '..')
+sys_path = os.path.normpath(sys_path)
+if sys_path not in sys.path:
+    sys.path.insert(0, sys_path)
+
+# local imports
+# pylint: disable=wrong-import-position
+from log import LoggingHandler, print_logfile_line, read_and_log
+from ccx2paraview.common import Converter
+from ccx2paraview.cli import clean_screen
+# pylint: enable=wrong-import-position
+
+file_path = os.path.abspath(__file__)
+dir_path = os.path.dirname(file_path)
+dir_path_logs = os.path.normpath(os.path.join(dir_path, 'test_logs'))
+dir_path_frds = os.path.normpath(os.path.join(dir_path, 'sim_frds'))
+N_CORE = int(8)
+
+def clean_cache(folder:str=None):
+    """Recursively delete cached files in all subfolders."""
+    if folder is None:
+        folder = os.getcwd()
+    pycache = os.path.join(folder, '__pycache__')
+    if os.path.isdir(pycache):
+        shutil.rmtree(pycache) # works in Linux as in Windows
+
+    # Recursively clear cache in child folders
+    try:
+        for f in os.scandir(folder):
+            if f.is_dir():
+                clean_cache(f.path)
+    except PermissionError:
+        logging.error('Insufficient permissions for %s', dir)
+
+def clean_results_keep_vtx(folder:str=None):
+    """Cleaup old result files keeping the interesting results."""
+    if folder is None:
+        folder = os.getcwd()
+    extensions = ('.dat', '.cvg', '.sta', '.out', '.12d')
+    for f in os.scandir(folder):
+        if f.is_dir():
+            clean_results(f.path)
+        if f.name.endswith(extensions):
+            try:
+                os.remove(f.path)
+                sys.__stdout__.write('Deleted ' + f.path + '\n')
+            except OSError:
+                sys.__stdout__.write(f.path + ': ' + sys.exc_info()[1][1] + '\n')
+
+def clean_results(folder:str=None):
+    """Cleaup old result files."""
+    if folder is None:
+        folder = os.getcwd()
+    extensions = ('.vtk', '.vtu', '.pvd', '.dat', '.cvg', '.sta', '.out', '.12d')
+    for f in os.scandir(folder):
+        if f.is_dir():
+            clean_results(f.path)
+        if f.name.endswith(extensions):
+            try:
+                os.remove(f.path)
+                sys.__stdout__.write('Deleted ' + f.path + '\n')
+            except OSError:
+                sys.__stdout__.write(f.path + ': ' + sys.exc_info()[1][1] + '\n')
+
+def get_time_delta(delta):
+    """Return spent time delta in format mm:ss.s."""
+    return f'{int(delta%3600/60):d}m {delta%3600%60:.1f}s'
+
+def ccx_and_convert_single_file(modelname, inp_path:str=None):
+    """solve and convert a single model"""
+    ccx_single_file(modelname, inp_path)
+    convert_single_file(modelname)
+
+def ccx_single_file(modelname, inp_path:str=None):
+    """solve a single model"""
+
+    if inp_path is not None:
+        try:
+            shutil.copy(\
+                os.path.normpath(os.path.join(os.getcwd(), f'{inp_path}', f'{modelname}.inp')), \
+                    os.path.normpath(os.path.join(f'{dir_path_frds}', f'{modelname}.inp')))
+        # pylint: disable-next=broad-exception-caught
+        except Exception as e:
+            logging.error(e)
+
+    log_file = os.path.normpath(os.path.join(dir_path_logs, f'{modelname}.ccx.log'))
+    try:
+        # Prepare logging
+        logging_handler_sim = LoggingHandler(log_file)
+        logging.getLogger().addHandler(logging_handler_sim)
+        logging.getLogger().setLevel(logging.DEBUG)
+        print_logfile_line('SIMULATE')
+        print_logfile_line('')
+        print_logfile_line(f'INFO: Reading {modelname}.inp')
+        print_logfile_line(f'INFO: run ccx with {N_CORE} core(s)')
+        start = time.perf_counter()
+
+        # run ccx
+        env = os.environ
+        env['OMP_NUM_THREADS'] = str(N_CORE)
+        with subprocess.Popen([shutil.which('ccx'), '-i', modelname],\
+                              stdin=subprocess.PIPE,\
+                              stdout=subprocess.PIPE,\
+                              stderr=subprocess.STDOUT,\
+                              cwd=dir_path_frds,\
+                              env=env) as sim_process:
+            read_and_log(sim_process.stdout)
+        delta = time.perf_counter() - start
+        print_logfile_line(get_time_delta(delta))
+        # end logging
+        logging.getLogger().removeHandler(logging_handler_sim)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        logging.error(e)
+
+def convert_single_file(modelname):
+    """test conversion of a single file"""
+    frd_file = os.path.normpath(os.path.join(dir_path_frds, f'{modelname}.frd'))
+    log_file = os.path.normpath(os.path.join(dir_path_logs, f'{modelname}.convert.log'))
+    try:
+        # Prepare logging
+        logging_handler = LoggingHandler(log_file)
+        logging.getLogger().addHandler(logging_handler)
+        logging.getLogger().setLevel(logging.DEBUG)
+        print_logfile_line('CONVERTER TEST')
+        print_logfile_line('')
+        start = time.perf_counter()
+        ccx2paraview = Converter(frd_file, ['vtk', 'vtu'])
+        ccx2paraview.run()
+        delta = time.perf_counter() - start
+        print_logfile_line(get_time_delta(delta))
+        # end logging
+        logging.getLogger().removeHandler(logging_handler)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        logging.error(e)
+
+def convert_single_file_vtu(modelname):
+    """test conversion of a single file to vtu"""
+    frd_file = os.path.normpath(os.path.join(dir_path_frds, f'{modelname}.frd'))
+    log_file = os.path.normpath(os.path.join(dir_path_logs, f'{modelname}.convert.log'))
+    try:
+        # Prepare logging
+        logging_handler = LoggingHandler(log_file)
+        logging.getLogger().addHandler(logging_handler)
+        logging.getLogger().setLevel(logging.DEBUG)
+        print_logfile_line('CONVERTER TEST')
+        print_logfile_line('')
+        start = time.perf_counter()
+        ccx2paraview = Converter(frd_file, ['vtu'])
+        ccx2paraview.run()
+        delta = time.perf_counter() - start
+        print_logfile_line(get_time_delta(delta))
+        # end logging
+        logging.getLogger().removeHandler(logging_handler)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        logging.error(e)
+    
+def convert_single_file_vtk(modelname):
+    """test conversion of a single file to vtk"""
+    frd_file = os.path.normpath(os.path.join(dir_path_frds, f'{modelname}.frd'))
+    log_file = os.path.normpath(os.path.join(dir_path_logs, f'{modelname}.convert.log'))
+    try:
+        # Prepare logging
+        logging_handler = LoggingHandler(log_file)
+        logging.getLogger().addHandler(logging_handler)
+        logging.getLogger().setLevel(logging.DEBUG)
+        print_logfile_line('CONVERTER TEST')
+        print_logfile_line('')
+        start = time.perf_counter()
+        ccx2paraview = Converter(frd_file, ['vtk'])
+        ccx2paraview.run()
+        delta = time.perf_counter() - start
+        print_logfile_line(get_time_delta(delta))
+        # end logging
+        logging.getLogger().removeHandler(logging_handler)
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        logging.error(e)
+
+# Run
+if __name__ == '__main__':
+    os.chdir(os.path.dirname(__file__))
+
+    # create folders if not present
+    try:
+        os.mkdir(dir_path_logs)
+        print(f"Directory '{dir_path_logs}' created successfully.")
+    except FileExistsError:
+        print(f"Directory '{dir_path_logs}' already exists.")
+    except PermissionError:
+        print(f"Permission denied: Unable to create '{dir_path_logs}'.")
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    try:
+        os.mkdir(dir_path_frds)
+        print(f"Directory '{dir_path_frds}' created successfully.")
+    except FileExistsError:
+        print(f"Directory '{dir_path_frds}' already exists.")
+    except PermissionError:
+        print(f"Permission denied: Unable to create '{dir_path_frds}'.")
+    # pylint: disable-next=broad-exception-caught
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    clean_cache()
+    clean_results(dir_path_logs)
+    clean_results(dir_path_frds)
+    clean_screen()
+
+    # ccx_and_convert_single_file('Ihor_Mirzov_baffle_2D', '../../examples/other')
+    # ccx_and_convert_single_file('ball', '../../examples/other')
+    # ccx_and_convert_single_file('dichtstoff_2_HE8', '../../examples/other')
+    # ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_staticbeam2', '../../examples/other')
+    # ccx_and_convert_single_file('Kaffeeheblerei_hinge', '../../examples/other')
+    ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_beammodal', '../../examples/other')
+
+    clean_cache()
+    clean_results_keep_vtx(dir_path_frds)

--- a/tests/test.log
+++ b/tests/test.log
@@ -1,68 +1,16 @@
 CONVERTER TEST
-INFO: Reading John_Mannisto_blade_sector.frd
-INFO: 1720 nodes
-INFO: 832 cells
-INFO: 15 time increments
-INFO: Step 1, time 87.1, U, 3 components, 1720 values
-INFO: Step 1, time 87.1, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.01.vtk
-INFO: Writing John_Mannisto_blade_sector.01.vtu
-INFO: Step 3, time 204.1, U, 3 components, 1720 values
-INFO: Step 3, time 204.1, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.02.vtk
-INFO: Writing John_Mannisto_blade_sector.02.vtu
-INFO: Step 5, time 316.1, U, 3 components, 1720 values
-INFO: Step 5, time 316.1, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.03.vtk
-INFO: Writing John_Mannisto_blade_sector.03.vtu
-INFO: Step 6, time 89.2, U, 3 components, 1720 values
-INFO: Step 6, time 89.2, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.04.vtk
-INFO: Writing John_Mannisto_blade_sector.04.vtu
-INFO: Step 8, time 200.5, U, 3 components, 1720 values
-INFO: Step 8, time 200.5, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.05.vtk
-INFO: Writing John_Mannisto_blade_sector.05.vtu
-INFO: Step 10, time 316.1, U, 3 components, 1720 values
-INFO: Step 10, time 316.1, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.06.vtk
-INFO: Writing John_Mannisto_blade_sector.06.vtu
-INFO: Step 11, time 89.3, U, 3 components, 1720 values
-INFO: Step 11, time 89.3, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.07.vtk
-INFO: Writing John_Mannisto_blade_sector.07.vtu
-INFO: Step 13, time 206.2, U, 3 components, 1720 values
-INFO: Step 13, time 206.2, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.08.vtk
-INFO: Writing John_Mannisto_blade_sector.08.vtu
-INFO: Step 15, time 317.5, U, 3 components, 1720 values
-INFO: Step 15, time 317.5, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.09.vtk
-INFO: Writing John_Mannisto_blade_sector.09.vtu
-INFO: Step 16, time 88.5, U, 3 components, 1720 values
-INFO: Step 16, time 88.5, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.10.vtk
-INFO: Writing John_Mannisto_blade_sector.10.vtu
-INFO: Step 18, time 215.5, U, 3 components, 1720 values
-INFO: Step 18, time 215.5, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.11.vtk
-INFO: Writing John_Mannisto_blade_sector.11.vtu
-INFO: Step 20, time 318.4, U, 3 components, 1720 values
-INFO: Step 20, time 318.4, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.12.vtk
-INFO: Writing John_Mannisto_blade_sector.12.vtu
-INFO: Step 21, time 88.2, U, 3 components, 1720 values
-INFO: Step 21, time 88.2, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.13.vtk
-INFO: Writing John_Mannisto_blade_sector.13.vtu
-INFO: Step 23, time 218.8, U, 3 components, 1720 values
-INFO: Step 23, time 218.8, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.14.vtk
-INFO: Writing John_Mannisto_blade_sector.14.vtu
-INFO: Step 25, time 318.6, U, 3 components, 1720 values
-INFO: Step 25, time 318.6, DISPI, 3 components, 1720 values
-INFO: Writing John_Mannisto_blade_sector.15.vtk
-INFO: Writing John_Mannisto_blade_sector.15.vtu
-0m 1.0s
+INFO: Reading beam.frd
+INFO: 4403 nodes
+INFO: 2340 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 4403 values
+INFO: Step 1, time 1.0, S, 6 components, 4403 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 4403 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 4403 values
+INFO: Step 1, time 1.0, RF, 3 components, 4403 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 4403 values
+INFO: Writing beam.vtk
+INFO: Writing beam.vtu
+0m 0.2s
 
-Total 0m 1.0s
+Total 0m 0.2s

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,9 +23,12 @@ sys_path = os.path.normpath(sys_path)
 if sys_path not in sys.path:
     sys.path.insert(0, sys_path)
 
+# local imports
+# pylint: disable=wrong-import-position
 from log import LoggingHandler, print_logfile_line
 from ccx2paraview.cli import clean_screen
 from ccx2paraview.common import Converter
+# pylint: enable=wrong-import-position
 
 def clean_cache(folder=None):
     """Recursively delete cached files in all subfolders."""

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,9 +23,9 @@ sys_path = os.path.normpath(sys_path)
 if sys_path not in sys.path:
     sys.path.insert(0, sys_path)
 
-from ccx2paraview import clean_screen, Converter
-from log import myHandler, print
-
+from log import LoggingHandler, print_logfile_line
+from ccx2paraview.cli import clean_screen
+from ccx2paraview.common import Converter
 
 def clean_cache(folder=None):
     """Recursively delete cached files in all subfolders."""
@@ -83,7 +83,7 @@ def test_my_parser_in(folder):
     """Convert calculation results."""
     for counter, file_path in enumerate(scan_all_files_in(folder, '.frd')):
         relpath = os.path.relpath(file_path, start=folder)
-        print('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
+        print_logfile_line('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
         test_my_single_file(file_path)
 
 
@@ -96,7 +96,7 @@ def test_my_single_file(file_path):
         ccx2paraview = Converter(file_path, ['vtk', 'vtu'])
         ccx2paraview.run()
         delta = time.perf_counter() - start
-        print(get_time_delta(delta))
+        print_logfile_line(get_time_delta(delta))
     except:
         logging.error(traceback.format_exc())
 
@@ -104,7 +104,7 @@ def test_my_single_file(file_path):
 def test_freecad_parser_in(folder):
     for counter, file_path in enumerate(scan_all_files_in(folder, '.frd')):
         relpath = os.path.relpath(file_path, start=folder)
-        print('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
+        print_logfile_line('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
         test_freecad_single_file(file_path)
 
 
@@ -114,7 +114,7 @@ def test_freecad_single_file(file_path):
         start = time.perf_counter()
         read_frd_result(file_path)
         delta = time.perf_counter() - start
-        print(get_time_delta(delta))
+        print_logfile_line(get_time_delta(delta))
     except:
         logging.error(traceback.format_exc())
 
@@ -129,7 +129,7 @@ def test_binary_in(folder):
             command = './bin/ccx2paraview'
         relpath = os.path.relpath(file_path, start=folder)
         for fmt in ['vtk', 'vtu']:
-            print('\n{}\n{}: {}'.format('='*50, counter, relpath))
+            print_logfile_line('\n{}\n{}: {}'.format('='*50, counter, relpath))
             cmd = [command, file_path, fmt]
             try:
                 process = subprocess.Popen(cmd,
@@ -144,29 +144,29 @@ def test_binary_in(folder):
 def test_numpy():
     import numpy as np
     a = np.zeros([10, 2])
-    print(a[:, 0])
+    print_logfile_line(a[:, 0])
 
 
-def test_NodalPointCoordinateBlock2():
-    from ccx2paraview import NodalPointCoordinateBlock2
-    file_path = os.path.join(os.path.dirname(__file__), 'pd.txt')
-    with open(file_path, 'r') as in_file:
-        node_block = NodalPointCoordinateBlock2(in_file)
-        print(node_block.nodes.head())
-        coords = node_block.get_node_coordinates(5)
-        print(coords)
+# def test_NodalPointCoordinateBlock2():
+#     from ccx2paraview import NodalPointCoordinateBlock2
+#     file_path = os.path.join(os.path.dirname(__file__), 'pd.txt')
+#     with open(file_path, 'r') as in_file:
+#         node_block = NodalPointCoordinateBlock2(in_file)
+#         print(node_block.nodes.head())
+#         coords = node_block.get_node_coordinates(5)
+#         print(coords)
 
 
 def test_lin_indexes():
     line = ' -1         1-6.64251E-02-6.64250E-02-1.54991E-01-1.06122E-08-1.43067E-02 3.02626E-02'
-    print(line[:5])
-    print(line[5:13])
-    print(line[13:25])
-    print(line[25:37])
-    print(line[37:49])
-    print(line[49:61])
-    print(line[61:73])
-    print(line[73:85])
+    print_logfile_line(line[:5])
+    print_logfile_line(line[5:13])
+    print_logfile_line(line[13:25])
+    print_logfile_line(line[25:37])
+    print_logfile_line(line[37:49])
+    print_logfile_line(line[49:61])
+    print_logfile_line(line[61:73])
+    print_logfile_line(line[73:85])
 
 
 # Run
@@ -178,15 +178,19 @@ if __name__ == '__main__':
     clean_screen()
     start = time.perf_counter()
 
+    log_file = os.path.abspath(__file__)
+    log_file = os.path.dirname(log_file)
+    log_file = os.path.join(log_file, 'test.log')
+
     # test_numpy()
     # test_NodalPointCoordinateBlock2()
     # test_lin_indexes()
     # raise SystemExit()
 
     # Prepare logging
-    logging.getLogger().addHandler(myHandler())
+    logging.getLogger().addHandler(LoggingHandler(log_file))
     logging.getLogger().setLevel(logging.DEBUG)
-    print('CONVERTER TEST\n\n')
+    print_logfile_line('CONVERTER TEST\n\n')
 
     # test_freecad_parser_in(d)
     # test_freecad_single_file(d + '/other/Sergio_Pluchinsky_PLASTIC_2ND_ORDER.frd_')
@@ -207,5 +211,5 @@ if __name__ == '__main__':
     # test_my_single_file(d + '/mkraska/Test/BeamSections/Refs/u1General.frd')
 
     delta = time.perf_counter() - start
-    print('\nTotal', get_time_delta(delta))
+    print_logfile_line('\nTotal', get_time_delta(delta))
     clean_cache()


### PR DESCRIPTION
Fixed the syntax warning on invalid escape sequence (the regex-strings just needed to have a r prepended).

Cleaned Up the code (with pylint).

Added a new file in tests to simulate from python and evaluate.
(I added an explanation in simulate_and_test.py on how to use it)

Done some test to check that it's really working: 
* see simulate_and_test.py for some tested examples
* e.g. the ball example (took nearly 5 min to simulate) - conversion to vtu was only 1.2 secs

I also fixed issue https://github.com/calculix/ccx2paraview/issues/32 as I wasn't able to open the ball.pvd in ParaView

BR,
Robert