### PR TITLE
added vtkhdf writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Distributed under GNU General Public License v3.0
 
 <br/><br/>
 
-# CalculiX to Paraview converter (frd to vtk/vtu)
+# CalculiX to Paraview converter (frd to vtk/vtu/vtkhdf)
 
 Converts [CalculiX](http://www.dhondt.de/) ASCII .frd-file to view and postprocess analysis results in [Paraview](https://www.paraview.org/). Generates von Mises and principal components for stress and strain tensors.
 
-Creates separate file for each output interval - it makes possible to animate time history. **Caution!** If you have 300 time steps in the FRD, there will be 300 Paraview files. If you need one file - write output only for one step in your CalculiX model.
+Creates separate file for each output interval - it makes possible to animate time history. **Caution!** If you have 300 time steps in the FRD, there will be 300 Paraview files. If you need one file - write output only for one step in your CalculiX model or write a .hdfvtk-file combining all time steps into one file.
 
 Converter is tested on [CalculiX examples](https://github.com/calculix/examples). Here is how some [test log](https://github.com/calculix/ccx2paraview/blob/master/tests/test.log) looks like.
 
@@ -185,13 +185,15 @@ Run converter with command:
 
     ccx2paraview yourjobname.frd vtk
     ccx2paraview yourjobname.frd vtu
+    ccx2paraview yourjobname.frd hdf
 
-Also you can pass both formats to convert .frd to .vtk and .vtu at once.
+Also you can pass more than one format to convert .frd to .vtk, .vtu or .vtkhdf at once.
 
 There are also the following aliases for converting files to a fixed format
 
     ccxToVTK yourjobname.frd
     ccxToVTU yourjobname.frd
+    ccxToHDF yourjobname.frd
 
 ### Using ccx2paraview in your python code
 

--- a/ccx2paraview/__init__.py
+++ b/ccx2paraview/__init__.py
@@ -1,4 +1,4 @@
-"""Make ccx2paraview a regular package."""
+"""ccx2paraview package"""
 
 from . import common
 from .common import Converter

--- a/ccx2paraview/__main__.py
+++ b/ccx2paraview/__main__.py
@@ -1,4 +1,4 @@
-"""For nuitka build..."""
+"""Command Line Interface for ccx2paraview package."""
 
 from . import cli
 

--- a/ccx2paraview/cli.py
+++ b/ccx2paraview/cli.py
@@ -40,7 +40,8 @@ def main():
     # Command line arguments
     ap = argparse.ArgumentParser()
     ap.add_argument('filename', type=filename_type, help='FRD file name with extension')
-    ap.add_argument('format', type=str, nargs='+', help='Output format', choices=['vtk', 'vtu'])
+    ap.add_argument('format', type=str, nargs='+', help='Output format',\
+                    choices=['vtk', 'vtu', 'hdf'])
     args = ap.parse_args()
 
     # Create converter and run it
@@ -67,11 +68,13 @@ def ccx_to_vtk():
     """Create and run a converter with vtk format."""
     main_with_format("vtk")
 
-
 def ccx_to_vtu():
     """Create and run a converter with vtu format."""
     main_with_format("vtu")
 
+def ccx_to_hdf():
+    """Create and run a converter with hdf format."""
+    main_with_format("hdf")
 
 #if __name__ == '__main__':
 #    clean_screen()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Repository = "https://github.com/calculix/ccx2paraview"
 ccx2paraview = "ccx2paraview.cli:main"
 ccxToVTK = "ccx2paraview.cli:ccx_to_vtk"
 ccxToVTU = "ccx2paraview.cli:ccx_to_vtu"
+ccxToHDF = "ccx2paraview.cli:ccx_to_hdf"
 
 [tool.setuptools-git-versioning]
 enabled = true


### PR DESCRIPTION
For my use case a single file output including all time steps is needed, thus I added 'hdf' as an option for the converter: will create an .vtkhdf-file including all of the timestamps that can be opened in ParaView.

Have tested some of the calculix examples, they'll converted fine with minor speed penalty (e.g. the ball example took 0.9 secs for 8 vtus and the pvd and 1.0 secs for vtkhdf). 
The tested examples opened flawlessly in ParaView. 
Still, the .vtkhdf-files are quite large, I'll investigate into compression further...

The idea of the converter to vtkhdf was sketched in: https://discourse.vtk.org/t/converting-from-vtu-files-to-transient-vtkhdf-file/13246/2

BR,
Robert