### PR TITLE
Prepare 3.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,43 @@ FRD reader is tested to reduce processing time as much as possible. Now it's qui
 
 ### Installation
 
-To install and run the latest release (version 3.2.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/) or [conda](https://docs.anaconda.com/miniconda/miniconda-install/): 
+#### Installation with pip or pipx
 
-    pip install vtk ccx2paraview
+To install and run the latest release (version 3.2.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/). 
+
+    # install via pip:
+    pip install ccx2paraview
     # or, with pipx:
-    pipx install vtk ccx2paraview
-    # or, within a new conda environment: 
-    conda create -n ccx2paraview_rel numpy paraview ccx2paraview
+    pipx install ccx2paraview
+
+VTK needs to be available on your system for ccx2paraview to run, either directly or from ParaView's python package. When you have neither, install VTK as an optional dependency alongside: 
+
+    # install via pip:
+    pip install ccx2paraview[VTK]
+    # or, with pipx:
+    pipx install ccx2paraview[VTK]
+
+
+#### Installation with a conda environment
+
+You can also use a [conda](https://docs.anaconda.com/miniconda/miniconda-install/) environment to install ccx2paraview:
+
+    # Install to a new conda environment: 
+    conda create -n ccx2paraview_env numpy paraview ccx2paraview
+
+**Hint!**  Don't forget to activate the conda environment before trying to use ccx2paraview:
+
+    conda activate ccx2paraview_env
 
 **Hint!** Installing paraview and ccx2paraview from the conda-forge channel can be achieved by adding conda-forge to your channels with:
 
     conda config --add channels conda-forge
     conda config --set channel_priority strict
 
+
 ### Usage 
 
-Having installed ccx2paraview via pip, pipx or conda, run converter with command (both in Linux and in Windows):
+Having installed ccx2paraview, run the converter with command (both in Linux and in Windows):
 
     ccx2paraview yourjobname.frd vtk
     ccx2paraview yourjobname.frd vtu

--- a/README.md
+++ b/README.md
@@ -45,21 +45,19 @@ FRD reader is tested to reduce processing time as much as possible. Now it's qui
 
 #### Installation with pip or pipx
 
-To install and run the latest release (version 3.2.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/). 
+To install and run the latest release (version 3.2.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) (Python >= 3.9). 
 
     # install via pip:
     pip install ccx2paraview
-    # or, with pipx:
-    pipx install ccx2paraview
 
-VTK needs to be available on your system for ccx2paraview to run, either directly or from ParaView's python package. When you have neither, install VTK as an optional dependency alongside: 
+VTK needs to be available on your system for ccx2paraview to run, either directly or from ParaView's python package. When you have neither, install VTK as an optional dependency alongside (works also with [pipx](https://pipx.pypa.io/stable/installation/) to install [apps](#usage), which are exposed on your $PATH and will be run in an isolated environment): 
 
     # install via pip:
     pip install 'ccx2paraview[VTK]'
     # or, with pipx:
     pipx install 'ccx2paraview[VTK]' 
 
-**Attention!** Using vtk and numpy in python 3.13 concurrently seems broken. When using pipx, set a python version <3.13, e.g.:
+**Attention!** Using vtk and numpy concurrently seems broken in python 3.13. When using pipx on a computer with Python 3.13, install ccx2paraview with a python version < 3.13, e.g.:
 
     pipx install 'ccx2paraview[VTK]' --python 3.12
 
@@ -96,7 +94,7 @@ There are also the following aliases for converting files to a fixed format
 
 #### Using ccx2paraview in your python code
 
-To use the current release of ccx2paraview in your python code:
+To use the current release of ccx2paraview in your python code (having installed with pip or into a conda environment):
 
 ```Python
 import logging
@@ -143,7 +141,6 @@ Starting from ccx2paraview v3.0.0 legacy .vtk format is also fully supported - p
 
 Installation of the latest release via pip was tested with a fresh install of vtk and numpy and:
 
-* Python 3.8: ERROR: No matching distribution found for vtk
 * Python 3.9: works!
 * Python 3.10: works!
 * Python 3.11: works!
@@ -152,7 +149,6 @@ Installation of the latest release via pip was tested with a fresh install of vt
 
 Using a conda-environment (with numpy and paraview):
 
-* Python 3.8: works!
 * Python 3.9: works!
 * Python 3.10: works!
 * Python 3.11: works!

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ FRD reader is tested to reduce processing time as much as possible. Now it's qui
 
 ### Installation
 
-To install and run the latest release (version 3.1.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/) or [conda](https://docs.anaconda.com/miniconda/miniconda-install/): 
+To install and run the latest release (version 3.2.0) of of this converter you'll need [Python 3](https://www.python.org/downloads/) and optionally [pipx](https://pipx.pypa.io/stable/installation/) or [conda](https://docs.anaconda.com/miniconda/miniconda-install/): 
 
-    pip install ccx2paraview
+    pip install vtk ccx2paraview
     # or, with pipx:
-    pipx install ccx2paraview
+    pipx install vtk ccx2paraview
     # or, within a new conda environment: 
     conda create -n ccx2paraview_rel numpy paraview ccx2paraview
 
@@ -58,23 +58,50 @@ To install and run the latest release (version 3.1.0) of of this converter you'l
 
 ### Usage 
 
-Having installed ccx2paraview via pip or pipx, you'll need to either cd into the ccx2paraview-directory, or add it to your PATH. Then, run converter with command (both in Linux and in Windows):
-
-    python ccx2paraview.py yourjobname.frd vtk
-    python ccx2paraview.py yourjobname.frd vtu
-
-Also you can pass both formats to convert .frd to .vtk and .vtu at once.
-
-Using the conda environment as described above, an additional binary is provided (thanks to conda-forge's package).
-Activate the conda-environment first:
-
-    conda activate ccx2paraview_rel
-
-Then, run converter from the python source as described above or use the provided binary:
+Having installed ccx2paraview via pip, pipx or conda, run converter with command (both in Linux and in Windows):
 
     ccx2paraview yourjobname.frd vtk
     ccx2paraview yourjobname.frd vtu
 
+Also you can pass both formats to convert .frd to .vtk and .vtu at once.
+
+There are also the following aliases for converting files to a fixed format
+
+    ccxToVTK yourjobname.frd
+    ccxToVTU yourjobname.frd
+
+#### Using ccx2paraview in your python code
+
+To use the current release of ccx2paraview in your python code:
+
+```Python
+import logging
+from ccx2paraview import Converter
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+c = Converter(frd_file_name, ['vtu'])
+c.run()
+```
+
+#### Create vtkhdf-file using ParaView's simple Module
+
+While ccx2paraview cannot convert to vtkhdf directly (yet), you can create such a single file bundling all of the timesteps into one by using ParaView's [simple Module](https://www.paraview.org/paraview-docs/latest/python/paraview.simple.html).
+When you are using a [conda environment](#installation) with ParaView, a working version of ParaView's simple Module should be available in the environment.  
+
+```Python
+# use ccx2paraview to convert the file '/Users/ccx/ball.frd' 
+# into vtu-files ('/Users/ccx/ball.x.vtu') and write a pvd-file
+from ccx2paraview import Converter
+c = Converter('/Users/ccx/ball.frd', ['vtu'])
+c.run()
+
+# Convert all vtu-files into one vtkhdf file 
+# - the .vtkhdf-extension is mandatory for ParaView to write the correct output
+# - The Compression level (0-9) is set to 4 here, making the vtkhdf-file 
+#   roughly the same size as the input vtus toghether
+from paraview.simple import (SaveData, PVDReader)
+pvd_proxy = PVDReader(registrationName='ball', FileName='/Users/ccx/ball.pvd')
+SaveData('/Users/ccx/ball.vtkhdf', proxy=pvd_proxy, WriteAllTimeSteps=1, CompressionLevel=4)
+```
 
 ### General Remarks
 
@@ -88,44 +115,25 @@ Starting from ccx2paraview v3.0.0 legacy .vtk format is also fully supported - p
 
 **Hint!** When using the [conda environment](#installation), a working version of ParaView should be available in the environment already.  
 
-#### Using ccx2paraview in your python code
-
-To use the current release of ccx2paraview in your python code:
-
-```Python
-import logging
-import ccx2paraview.ccx2paraview
-logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
-c = ccx2paraview.ccx2paraview.Converter(frd_file_name, ['vtu'])
-c.run()
-```
-
 #### Python Compatibility
 
-Installation of the latest release via pip was tested with a fresh install of:
+Installation of the latest release via pip was tested with a fresh install of vtk and numpy and:
 
-* Python 3.8: will install ccx2paraview v3.0.0
-* Python 3.9: will install ccx2paraview v3.0.0
+* Python 3.8: ERROR: No matching distribution found for vtk
+* Python 3.9: works!
 * Python 3.10: works!
 * Python 3.11: works!
-* Python 3.11: works!
-* Python 3.12: works - but will provoke SyntaxWarning: invalid escape sequence
-* Python 3.13: won't work - numpy-vtk incompatibility
-
-Using a conda-environment:
-
 * Python 3.12: works!
+* Python 3.13: ERROR: No matching distribution found for vtk
 
-```
-conda create -n ccx2paraview_rel python=3.12 numpy paraview ccx2paraview
-```
+Using a conda-environment (with numpy and paraview):
 
-* Python 3.13: works - but will provoke SyntaxWarning: invalid escape sequence
-
-```
-conda create -n ccx2paraview_rel numpy paraview ccx2paraview
-```
-
+* Python 3.8: works!
+* Python 3.9: works!
+* Python 3.10: works!
+* Python 3.11: works!
+* Python 3.12: works!
+* Python 3.13: works!
 
 ### Paraview **programmable filter**
 
@@ -184,52 +192,6 @@ To install this converter from github you'll need [Python 3](https://www.python.
 
 **Attention!** Currently, installing vtk via pip seems to break ParaView's pvpython. When using the conda environment, ParaView's included vtk will be used (alongside having a working ParaView in the environment).
 
-### Usage
-
-Run converter with command:
-
-    ccx2paraview yourjobname.frd vtk
-    ccx2paraview yourjobname.frd vtu
-
-Also you can pass both formats to convert .frd to .vtk and .vtu at once.
-
-There are also the following aliases for converting files to a fixed format
-
-    ccxToVTK yourjobname.frd
-    ccxToVTU yourjobname.frd
-
-#### Using ccx2paraview in your python code
-
-To use the development version of ccx2paraview in your python code:
-
-```Python
-import logging
-from ccx2paraview.common import Converter
-logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
-c = Converter(frd_file_name, ['vtu'])
-c.run()
-```
-
-#### Create vtkhdf-file using ParaView's simple Module
-
-While ccx2paraview cannot convert to vtkhdf directly (yet), you can create such a single file bundling all of the timesteps into one by using ParaView's [simple Module](https://www.paraview.org/paraview-docs/latest/python/paraview.simple.html).
-When you are using a [conda environment](#installation) with ParaView, a working version of ParaView's simple Module should be available in the environment.  
-
-```Python
-# use ccx2paraview to convert the file '/Users/ccx/ball.frd' 
-# into vtu-files ('/Users/ccx/ball.x.vtu') and write a pvd-file
-from ccx2paraview.common import Converter
-c = Converter('/Users/ccx/ball.frd', ['vtu'])
-c.run()
-
-# Convert all vtu-files into one vtkhdf file 
-# - the .vtkhdf-extension is mandatory for ParaView to write the correct output
-# - The Compression level (0-9) is set to 4 here, making the vtkhdf-file 
-#   roughly the same size as the input vtus toghether
-from paraview.simple import (SaveData, PVDReader)
-pvd_proxy = PVDReader(registrationName='ball', FileName='/Users/ccx/ball.pvd')
-SaveData('/Users/ccx/ball.vtkhdf', proxy=pvd_proxy, WriteAllTimeSteps=1, CompressionLevel=4)
-```
 
 <br/><br/>
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ To install and run the latest release (version 3.2.0) of of this converter you'l
 VTK needs to be available on your system for ccx2paraview to run, either directly or from ParaView's python package. When you have neither, install VTK as an optional dependency alongside: 
 
     # install via pip:
-    pip install ccx2paraview[VTK]
+    pip install 'ccx2paraview[VTK]'
     # or, with pipx:
-    pipx install ccx2paraview[VTK]
+    pipx install 'ccx2paraview[VTK]' 
 
+**Attention!** Using vtk and numpy in python 3.13 concurrently seems broken. When using pipx, set a python version <3.13, e.g.:
+
+    pipx install 'ccx2paraview[VTK]' --python 3.12
 
 #### Installation with a conda environment
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -656,9 +656,8 @@ class FRD:
 
         i = len(self.steps_increments)
         if i:
-            msg = f'{i} time increment {'s'*min(1, i-1)}'
+            msg = f'{i} time increment(s)'
             logging.info(msg)
-            # logging.debug('Steps-increments: {}'.format(self.steps_increments))
         else:
             logging.warning('No time increments!')
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -23,8 +23,8 @@ try:
     from vtk import (vtkUnstructuredGridWriter, vtkXMLUnstructuredGridWriter, \
                     vtkPoints, vtkCellArray, vtkUnstructuredGrid, vtkDoubleArray)
 except ImportError as e:
-    raise ImportError("Module vtk is not available: \
-                      Install either vtk or paraview before using ccx2paraview!") from e
+    raise ImportError("Module vtk is not available! "\
+                      "Install either vtk or paraview before using ccx2paraview.") from e
 
 renumbered_nodes = {} # old_number : new_number
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -23,8 +23,8 @@ try:
     from vtk import (vtkUnstructuredGridWriter, vtkXMLUnstructuredGridWriter, \
                     vtkPoints, vtkCellArray, vtkUnstructuredGrid, vtkDoubleArray)
 except ImportError as e:
-    raise ImportError("Module vtk is not available! "\
-                      "Install either vtk or paraview before using ccx2paraview.") from e
+    # pylint: disable-next=line-too-long
+    raise ImportError("Module vtk is not available! Install either vtk or paraview before using ccx2paraview.") from e
 
 renumbered_nodes = {} # old_number : new_number
 

--- a/ccx2paraview/common.py
+++ b/ccx2paraview/common.py
@@ -23,8 +23,8 @@ try:
     from vtk import (vtkUnstructuredGridWriter, vtkXMLUnstructuredGridWriter, \
                     vtkPoints, vtkCellArray, vtkUnstructuredGrid, vtkDoubleArray)
 except ImportError as e:
-    e.add_note("Install either vtk ar paraview.")
-    raise ImportError("Module vtk is not available!") from e
+    raise ImportError("Module vtk is not available: \
+                      Install either vtk or paraview before using ccx2paraview!") from e
 
 renumbered_nodes = {} # old_number : new_number
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name="ccx2paraview"
 dynamic = [ "version" ]
 dependencies = [ "numpy" ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Ihor Mirzov",  email="imirzov@gmail.com"}
 ]
@@ -21,7 +21,7 @@ classifiers=[
 "Development Status :: 4 - Beta",
 "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 "Programming Language :: Python :: 3 :: Only",
-"Programming Language :: Python :: 3.8",
+"Programming Language :: Python :: 3.9",
 "Topic :: Scientific/Engineering",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name="ccx2paraview"
 dynamic = [ "version" ]
-dependencies = [
-    "numpy"
-]
+dependencies = [ "numpy" ]
 requires-python = ">=3.8"
 authors = [
     { name = "Ihor Mirzov",  email="imirzov@gmail.com"}
@@ -28,9 +26,7 @@ classifiers=[
 ]
 
 [project.optional-dependencies]
-VTK = [
-    "VTK"
-]
+VTK = [ "vtk" ]
 
 [project.urls]
 Homepage = "https://github.com/calculix/ccx2paraview"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ classifiers=[
 "Topic :: Scientific/Engineering",
 ]
 
+[project.optional-dependencies]
+VTK = [
+    "VTK"
+]
+
 [project.urls]
 Homepage = "https://github.com/calculix/ccx2paraview"
 Documentation = "https://github.com/calculix/ccx2paraview"

--- a/tests/ccx2paraview_paraview.yaml
+++ b/tests/ccx2paraview_paraview.yaml
@@ -12,7 +12,7 @@ name: ccx2paraview_paraview
 channels: 
   - conda-forge
 dependencies:
-  - python 
+  - python
   - pip
-  - paraview
   - numpy
+  - paraview

--- a/tests/simulate_and_test.py
+++ b/tests/simulate_and_test.py
@@ -34,7 +34,7 @@ if sys_path not in sys.path:
 # local imports
 # pylint: disable=wrong-import-position
 from log import LoggingHandler
-from ccx2paraview.common import Converter
+from ccx2paraview import Converter
 from ccx2paraview.cli import clean_screen
 # pylint: enable=wrong-import-position
 
@@ -241,32 +241,32 @@ if __name__ == '__main__':
     clean_screen()
 
     # These examples won't run in ccx for me
-    #ccx_and_convert_single_file('Csati_Zoltan_many_sets', '../../examples/other')
-    #ccx_and_convert_single_file('Kandala_Stepan_Floor', '../../examples/other')
-    #ccx_and_convert_single_file('Sergio_Pluchinsky_piston', '../../examples/other')
+    # ccx_and_convert_single_file('Csati_Zoltan_many_sets', '../../examples/other')
+    # ccx_and_convert_single_file('Kandala_Stepan_Floor', '../../examples/other')
+    # ccx_and_convert_single_file('Sergio_Pluchinsky_piston', '../../examples/other')
 
     # These examples won't convert for me
-    #ccx_and_convert_single_file('gears', '../../examples/other')
+    # ccx_and_convert_single_file('gears', '../../examples/other')
     # ERROR: 'utf-8' codec can't decode byte 0x9a in position 966: invalid start byte
 
     # These work...
-    #ccx_and_convert_single_file('ball', '../../examples/other')
-    #ccx_and_convert_single_file('dichtstoff_2_HE8', '../../examples/other')
-    #ccx_and_convert_single_file('Dichtstoff_beam_coupling_compl', '../../examples/other')
-    #ccx_and_convert_single_file('Ihor_Mirzov_baffle_2D', '../../examples/other')
-    #ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_beammodal', '../../examples/other')
-    #ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_staticbeam2', '../../examples/other')
-    #ccx_and_convert_single_file('Jan_Lukas_static_structural', '../../examples/other')
-    #ccx_and_convert_single_file('John_Mannisto_blade_sector', '../../examples/other')
-    #ccx_and_convert_single_file('John_Mannisto_buckling_trick', '../../examples/other')
-    #ccx_and_convert_single_file('Kaffeeheblerei_hinge', '../../examples/other')
-    #ccx_and_convert_single_file('Nidish_Narayanaa_Balaji', '../../examples/other')
-    #ccx_and_convert_single_file('Spanner-in', '../../examples/other/ddjokic-CalculiX-tests-master/Spanner')
-    #ccx_and_convert_single_file('contact2e', '../../examples/ccx/structest')
-    #ccx_and_convert_single_file('contact2i', '../../examples/ccx/structest')
+    # ccx_and_convert_single_file('ball', '../../examples/other')
+    # ccx_and_convert_single_file('dichtstoff_2_HE8', '../../examples/other')
+    # ccx_and_convert_single_file('Dichtstoff_beam_coupling_compl', '../../examples/other')
+    # ccx_and_convert_single_file('Ihor_Mirzov_baffle_2D', '../../examples/other')
+    # ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_beammodal', '../../examples/other')
+    # ccx_and_convert_single_file('Jan_Lukas_modal_dynamic_staticbeam2', '../../examples/other')
+    # ccx_and_convert_single_file('Jan_Lukas_static_structural', '../../examples/other')
+    # ccx_and_convert_single_file('John_Mannisto_blade_sector', '../../examples/other')
+    # ccx_and_convert_single_file('John_Mannisto_buckling_trick', '../../examples/other')
+    # ccx_and_convert_single_file('Kaffeeheblerei_hinge', '../../examples/other')
+    # ccx_and_convert_single_file('Nidish_Narayanaa_Balaji', '../../examples/other')
+    # ccx_and_convert_single_file('Spanner-in', '../../examples/other/ddjokic-CalculiX-tests-master/Spanner')
+    # ccx_and_convert_single_file('contact2e', '../../examples/ccx/structest')
+    # ccx_and_convert_single_file('contact2i', '../../examples/ccx/structest')
 
     # Test conversion
-    convert_single_file_vtu('ball')
+    # convert_single_file_vtu('ball')
     # convert_single_file('dichtstoff_2_HE8')
     # convert_single_file('Dichtstoff_beam_coupling_compl')
     # convert_single_file('Ihor_Mirzov_baffle_2D')

--- a/tests/test.log
+++ b/tests/test.log
@@ -1,16 +1,1170 @@
 CONVERTER TEST
-INFO: Reading beam.frd
-INFO: 4403 nodes
-INFO: 2340 cells
-INFO: 1 time increment
-INFO: Step 1, time 1.0, U, 3 components, 4403 values
-INFO: Step 1, time 1.0, S, 6 components, 4403 values
-INFO: Step 1, time 1.0, S_Mises, 1 components, 4403 values
-INFO: Step 1, time 1.0, S_Principal, 4 components, 4403 values
-INFO: Step 1, time 1.0, RF, 3 components, 4403 values
-INFO: Step 1, time 1.0, ERROR, 1 components, 4403 values
-INFO: Writing beam.vtk
-INFO: Writing beam.vtu
-0m 0.2s
 
-Total 0m 0.2s
+
+==================================================
+1: other/Dichtstoff_beam_coupling_compl.frd
+INFO: Reading Dichtstoff_beam_coupling_compl.frd
+INFO: 378 nodes
+INFO: 160 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 378 values
+INFO: Step 1, time 1.0, S, 6 components, 378 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 378 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 378 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 378 values
+INFO: Writing Dichtstoff_beam_coupling_compl.vtk
+INFO: Writing Dichtstoff_beam_coupling_compl.vtu
+0m 0.0s
+
+==================================================
+2: other/Ihor_Mirzov_baffle_2D.frd
+INFO: Reading Ihor_Mirzov_baffle_2D.frd
+INFO: 14836 nodes
+INFO: 6778 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, NT, 1 components, 14836 values
+INFO: Writing Ihor_Mirzov_baffle_2D.vtk
+INFO: Writing Ihor_Mirzov_baffle_2D.vtu
+0m 0.1s
+
+==================================================
+3: other/Jan_Lukas_modal_dynamic_beammodal.frd
+INFO: Reading Jan_Lukas_modal_dynamic_beammodal.frd
+INFO: 1221 nodes
+INFO: 160 cells
+INFO: 16 time increment s
+INFO: Step 1, time 209.2, U, 3 components, 1221 values
+INFO: Step 1, time 209.2, S, 6 components, 1221 values
+INFO: Step 1, time 209.2, S_Mises, 1 components, 1221 values
+INFO: Step 1, time 209.2, S_Principal, 4 components, 1221 values
+INFO: Step 1, time 209.2, E, 6 components, 1221 values
+INFO: Step 1, time 209.2, E_Mises, 1 components, 1221 values
+INFO: Step 1, time 209.2, E_Principal, 4 components, 1221 values
+INFO: Step 1, time 209.2, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.01.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.01.vtu
+INFO: Step 2, time 209.2, U, 3 components, 1221 values
+INFO: Step 2, time 209.2, S, 6 components, 1221 values
+INFO: Step 2, time 209.2, S_Mises, 1 components, 1221 values
+INFO: Step 2, time 209.2, S_Principal, 4 components, 1221 values
+INFO: Step 2, time 209.2, E, 6 components, 1221 values
+INFO: Step 2, time 209.2, E_Mises, 1 components, 1221 values
+INFO: Step 2, time 209.2, E_Principal, 4 components, 1221 values
+INFO: Step 2, time 209.2, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.02.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.02.vtu
+INFO: Step 3, time 1296.2, U, 3 components, 1221 values
+INFO: Step 3, time 1296.2, S, 6 components, 1221 values
+INFO: Step 3, time 1296.2, S_Mises, 1 components, 1221 values
+INFO: Step 3, time 1296.2, S_Principal, 4 components, 1221 values
+INFO: Step 3, time 1296.2, E, 6 components, 1221 values
+INFO: Step 3, time 1296.2, E_Mises, 1 components, 1221 values
+INFO: Step 3, time 1296.2, E_Principal, 4 components, 1221 values
+INFO: Step 3, time 1296.2, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.03.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.03.vtu
+INFO: Step 4, time 1296.2, U, 3 components, 1221 values
+INFO: Step 4, time 1296.2, S, 6 components, 1221 values
+INFO: Step 4, time 1296.2, S_Mises, 1 components, 1221 values
+INFO: Step 4, time 1296.2, S_Principal, 4 components, 1221 values
+INFO: Step 4, time 1296.2, E, 6 components, 1221 values
+INFO: Step 4, time 1296.2, E_Mises, 1 components, 1221 values
+INFO: Step 4, time 1296.2, E_Principal, 4 components, 1221 values
+INFO: Step 4, time 1296.2, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.04.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.04.vtu
+INFO: Step 5, time 3565.9, U, 3 components, 1221 values
+INFO: Step 5, time 3565.9, S, 6 components, 1221 values
+INFO: Step 5, time 3565.9, S_Mises, 1 components, 1221 values
+INFO: Step 5, time 3565.9, S_Principal, 4 components, 1221 values
+INFO: Step 5, time 3565.9, E, 6 components, 1221 values
+INFO: Step 5, time 3565.9, E_Mises, 1 components, 1221 values
+INFO: Step 5, time 3565.9, E_Principal, 4 components, 1221 values
+INFO: Step 5, time 3565.9, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.05.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.05.vtu
+INFO: Step 6, time 3565.9, U, 3 components, 1221 values
+INFO: Step 6, time 3565.9, S, 6 components, 1221 values
+INFO: Step 6, time 3565.9, S_Mises, 1 components, 1221 values
+INFO: Step 6, time 3565.9, S_Principal, 4 components, 1221 values
+INFO: Step 6, time 3565.9, E, 6 components, 1221 values
+INFO: Step 6, time 3565.9, E_Mises, 1 components, 1221 values
+INFO: Step 6, time 3565.9, E_Principal, 4 components, 1221 values
+INFO: Step 6, time 3565.9, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.06.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.06.vtu
+INFO: Step 7, time 3714.6, U, 3 components, 1221 values
+INFO: Step 7, time 3714.6, S, 6 components, 1221 values
+INFO: Step 7, time 3714.6, S_Mises, 1 components, 1221 values
+INFO: Step 7, time 3714.6, S_Principal, 4 components, 1221 values
+INFO: Step 7, time 3714.6, E, 6 components, 1221 values
+INFO: Step 7, time 3714.6, E_Mises, 1 components, 1221 values
+INFO: Step 7, time 3714.6, E_Principal, 4 components, 1221 values
+INFO: Step 7, time 3714.6, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.07.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.07.vtu
+INFO: Step 8, time 6477.3, U, 3 components, 1221 values
+INFO: Step 8, time 6477.3, S, 6 components, 1221 values
+INFO: Step 8, time 6477.3, S_Mises, 1 components, 1221 values
+INFO: Step 8, time 6477.3, S_Principal, 4 components, 1221 values
+INFO: Step 8, time 6477.3, E, 6 components, 1221 values
+INFO: Step 8, time 6477.3, E_Mises, 1 components, 1221 values
+INFO: Step 8, time 6477.3, E_Principal, 4 components, 1221 values
+INFO: Step 8, time 6477.3, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.08.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.08.vtu
+INFO: Step 9, time 6819.4, U, 3 components, 1221 values
+INFO: Step 9, time 6819.4, S, 6 components, 1221 values
+INFO: Step 9, time 6819.4, S_Mises, 1 components, 1221 values
+INFO: Step 9, time 6819.4, S_Principal, 4 components, 1221 values
+INFO: Step 9, time 6819.4, E, 6 components, 1221 values
+INFO: Step 9, time 6819.4, E_Mises, 1 components, 1221 values
+INFO: Step 9, time 6819.4, E_Principal, 4 components, 1221 values
+INFO: Step 9, time 6819.4, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.09.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.09.vtu
+INFO: Step 10, time 6819.4, U, 3 components, 1221 values
+INFO: Step 10, time 6819.4, S, 6 components, 1221 values
+INFO: Step 10, time 6819.4, S_Mises, 1 components, 1221 values
+INFO: Step 10, time 6819.4, S_Principal, 4 components, 1221 values
+INFO: Step 10, time 6819.4, E, 6 components, 1221 values
+INFO: Step 10, time 6819.4, E_Mises, 1 components, 1221 values
+INFO: Step 10, time 6819.4, E_Principal, 4 components, 1221 values
+INFO: Step 10, time 6819.4, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.10.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.10.vtu
+INFO: Step 11, time 10945.6, U, 3 components, 1221 values
+INFO: Step 11, time 10945.6, S, 6 components, 1221 values
+INFO: Step 11, time 10945.6, S_Mises, 1 components, 1221 values
+INFO: Step 11, time 10945.6, S_Principal, 4 components, 1221 values
+INFO: Step 11, time 10945.6, E, 6 components, 1221 values
+INFO: Step 11, time 10945.6, E_Mises, 1 components, 1221 values
+INFO: Step 11, time 10945.6, E_Principal, 4 components, 1221 values
+INFO: Step 11, time 10945.6, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.11.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.11.vtu
+INFO: Step 12, time 10945.6, U, 3 components, 1221 values
+INFO: Step 12, time 10945.6, S, 6 components, 1221 values
+INFO: Step 12, time 10945.6, S_Mises, 1 components, 1221 values
+INFO: Step 12, time 10945.6, S_Principal, 4 components, 1221 values
+INFO: Step 12, time 10945.6, E, 6 components, 1221 values
+INFO: Step 12, time 10945.6, E_Mises, 1 components, 1221 values
+INFO: Step 12, time 10945.6, E_Principal, 4 components, 1221 values
+INFO: Step 12, time 10945.6, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.12.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.12.vtu
+INFO: Step 13, time 11144.0, U, 3 components, 1221 values
+INFO: Step 13, time 11144.0, S, 6 components, 1221 values
+INFO: Step 13, time 11144.0, S_Mises, 1 components, 1221 values
+INFO: Step 13, time 11144.0, S_Principal, 4 components, 1221 values
+INFO: Step 13, time 11144.0, E, 6 components, 1221 values
+INFO: Step 13, time 11144.0, E_Mises, 1 components, 1221 values
+INFO: Step 13, time 11144.0, E_Principal, 4 components, 1221 values
+INFO: Step 13, time 11144.0, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.13.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.13.vtu
+INFO: Step 14, time 15813.3, U, 3 components, 1221 values
+INFO: Step 14, time 15813.3, S, 6 components, 1221 values
+INFO: Step 14, time 15813.3, S_Mises, 1 components, 1221 values
+INFO: Step 14, time 15813.3, S_Principal, 4 components, 1221 values
+INFO: Step 14, time 15813.3, E, 6 components, 1221 values
+INFO: Step 14, time 15813.3, E_Mises, 1 components, 1221 values
+INFO: Step 14, time 15813.3, E_Principal, 4 components, 1221 values
+INFO: Step 14, time 15813.3, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.14.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.14.vtu
+INFO: Step 15, time 15813.3, U, 3 components, 1221 values
+INFO: Step 15, time 15813.3, S, 6 components, 1221 values
+INFO: Step 15, time 15813.3, S_Mises, 1 components, 1221 values
+INFO: Step 15, time 15813.3, S_Principal, 4 components, 1221 values
+INFO: Step 15, time 15813.3, E, 6 components, 1221 values
+INFO: Step 15, time 15813.3, E_Mises, 1 components, 1221 values
+INFO: Step 15, time 15813.3, E_Principal, 4 components, 1221 values
+INFO: Step 15, time 15813.3, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.15.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.15.vtu
+INFO: Step 16, time 18574.3, U, 3 components, 1221 values
+INFO: Step 16, time 18574.3, S, 6 components, 1221 values
+INFO: Step 16, time 18574.3, S_Mises, 1 components, 1221 values
+INFO: Step 16, time 18574.3, S_Principal, 4 components, 1221 values
+INFO: Step 16, time 18574.3, E, 6 components, 1221 values
+INFO: Step 16, time 18574.3, E_Mises, 1 components, 1221 values
+INFO: Step 16, time 18574.3, E_Principal, 4 components, 1221 values
+INFO: Step 16, time 18574.3, ERROR, 1 components, 1221 values
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.16.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.16.vtu
+INFO: Writing Jan_Lukas_modal_dynamic_beammodal.pvd
+0m 0.9s
+
+==================================================
+4: other/Jan_Lukas_modal_dynamic_staticbeam2.frd
+INFO: Reading Jan_Lukas_modal_dynamic_staticbeam2.frd
+INFO: 321 nodes
+INFO: 40 cells
+INFO: 16 time increment s
+INFO: Step 1, time 837.4, U, 3 components, 321 values
+INFO: Step 1, time 837.4, S, 6 components, 321 values
+INFO: Step 1, time 837.4, S_Mises, 1 components, 321 values
+INFO: Step 1, time 837.4, S_Principal, 4 components, 321 values
+INFO: Step 1, time 837.4, E, 6 components, 321 values
+INFO: Step 1, time 837.4, E_Mises, 1 components, 321 values
+INFO: Step 1, time 837.4, E_Principal, 4 components, 321 values
+INFO: Step 1, time 837.4, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.01.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.01.vtu
+INFO: Step 2, time 837.4, U, 3 components, 321 values
+INFO: Step 2, time 837.4, S, 6 components, 321 values
+INFO: Step 2, time 837.4, S_Mises, 1 components, 321 values
+INFO: Step 2, time 837.4, S_Principal, 4 components, 321 values
+INFO: Step 2, time 837.4, E, 6 components, 321 values
+INFO: Step 2, time 837.4, E_Mises, 1 components, 321 values
+INFO: Step 2, time 837.4, E_Principal, 4 components, 321 values
+INFO: Step 2, time 837.4, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.02.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.02.vtu
+INFO: Step 3, time 5026.9, U, 3 components, 321 values
+INFO: Step 3, time 5026.9, S, 6 components, 321 values
+INFO: Step 3, time 5026.9, S_Mises, 1 components, 321 values
+INFO: Step 3, time 5026.9, S_Principal, 4 components, 321 values
+INFO: Step 3, time 5026.9, E, 6 components, 321 values
+INFO: Step 3, time 5026.9, E_Mises, 1 components, 321 values
+INFO: Step 3, time 5026.9, E_Principal, 4 components, 321 values
+INFO: Step 3, time 5026.9, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.03.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.03.vtu
+INFO: Step 4, time 5026.9, U, 3 components, 321 values
+INFO: Step 4, time 5026.9, S, 6 components, 321 values
+INFO: Step 4, time 5026.9, S_Mises, 1 components, 321 values
+INFO: Step 4, time 5026.9, S_Principal, 4 components, 321 values
+INFO: Step 4, time 5026.9, E, 6 components, 321 values
+INFO: Step 4, time 5026.9, E_Mises, 1 components, 321 values
+INFO: Step 4, time 5026.9, E_Principal, 4 components, 321 values
+INFO: Step 4, time 5026.9, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.04.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.04.vtu
+INFO: Step 5, time 7452.8, U, 3 components, 321 values
+INFO: Step 5, time 7452.8, S, 6 components, 321 values
+INFO: Step 5, time 7452.8, S_Mises, 1 components, 321 values
+INFO: Step 5, time 7452.8, S_Principal, 4 components, 321 values
+INFO: Step 5, time 7452.8, E, 6 components, 321 values
+INFO: Step 5, time 7452.8, E_Mises, 1 components, 321 values
+INFO: Step 5, time 7452.8, E_Principal, 4 components, 321 values
+INFO: Step 5, time 7452.8, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.05.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.05.vtu
+INFO: Step 6, time 12989.9, U, 3 components, 321 values
+INFO: Step 6, time 12989.9, S, 6 components, 321 values
+INFO: Step 6, time 12989.9, S_Mises, 1 components, 321 values
+INFO: Step 6, time 12989.9, S_Principal, 4 components, 321 values
+INFO: Step 6, time 12989.9, E, 6 components, 321 values
+INFO: Step 6, time 12989.9, E_Mises, 1 components, 321 values
+INFO: Step 6, time 12989.9, E_Principal, 4 components, 321 values
+INFO: Step 6, time 12989.9, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.06.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.06.vtu
+INFO: Step 7, time 13260.2, U, 3 components, 321 values
+INFO: Step 7, time 13260.2, S, 6 components, 321 values
+INFO: Step 7, time 13260.2, S_Mises, 1 components, 321 values
+INFO: Step 7, time 13260.2, S_Principal, 4 components, 321 values
+INFO: Step 7, time 13260.2, E, 6 components, 321 values
+INFO: Step 7, time 13260.2, E_Mises, 1 components, 321 values
+INFO: Step 7, time 13260.2, E_Principal, 4 components, 321 values
+INFO: Step 7, time 13260.2, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.07.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.07.vtu
+INFO: Step 8, time 13260.2, U, 3 components, 321 values
+INFO: Step 8, time 13260.2, S, 6 components, 321 values
+INFO: Step 8, time 13260.2, S_Mises, 1 components, 321 values
+INFO: Step 8, time 13260.2, S_Principal, 4 components, 321 values
+INFO: Step 8, time 13260.2, E, 6 components, 321 values
+INFO: Step 8, time 13260.2, E_Mises, 1 components, 321 values
+INFO: Step 8, time 13260.2, E_Principal, 4 components, 321 values
+INFO: Step 8, time 13260.2, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.08.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.08.vtu
+INFO: Step 9, time 22364.5, U, 3 components, 321 values
+INFO: Step 9, time 22364.5, S, 6 components, 321 values
+INFO: Step 9, time 22364.5, S_Mises, 1 components, 321 values
+INFO: Step 9, time 22364.5, S_Principal, 4 components, 321 values
+INFO: Step 9, time 22364.5, E, 6 components, 321 values
+INFO: Step 9, time 22364.5, E_Mises, 1 components, 321 values
+INFO: Step 9, time 22364.5, E_Principal, 4 components, 321 values
+INFO: Step 9, time 22364.5, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.09.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.09.vtu
+INFO: Step 10, time 24163.3, U, 3 components, 321 values
+INFO: Step 10, time 24163.3, S, 6 components, 321 values
+INFO: Step 10, time 24163.3, S_Mises, 1 components, 321 values
+INFO: Step 10, time 24163.3, S_Principal, 4 components, 321 values
+INFO: Step 10, time 24163.3, E, 6 components, 321 values
+INFO: Step 10, time 24163.3, E_Mises, 1 components, 321 values
+INFO: Step 10, time 24163.3, E_Principal, 4 components, 321 values
+INFO: Step 10, time 24163.3, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.10.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.10.vtu
+INFO: Step 11, time 24163.3, U, 3 components, 321 values
+INFO: Step 11, time 24163.3, S, 6 components, 321 values
+INFO: Step 11, time 24163.3, S_Mises, 1 components, 321 values
+INFO: Step 11, time 24163.3, S_Principal, 4 components, 321 values
+INFO: Step 11, time 24163.3, E, 6 components, 321 values
+INFO: Step 11, time 24163.3, E_Mises, 1 components, 321 values
+INFO: Step 11, time 24163.3, E_Principal, 4 components, 321 values
+INFO: Step 11, time 24163.3, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.11.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.11.vtu
+INFO: Step 12, time 37022.9, U, 3 components, 321 values
+INFO: Step 12, time 37022.9, S, 6 components, 321 values
+INFO: Step 12, time 37022.9, S_Mises, 1 components, 321 values
+INFO: Step 12, time 37022.9, S_Principal, 4 components, 321 values
+INFO: Step 12, time 37022.9, E, 6 components, 321 values
+INFO: Step 12, time 37022.9, E_Mises, 1 components, 321 values
+INFO: Step 12, time 37022.9, E_Principal, 4 components, 321 values
+INFO: Step 12, time 37022.9, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.12.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.12.vtu
+INFO: Step 13, time 37022.9, U, 3 components, 321 values
+INFO: Step 13, time 37022.9, S, 6 components, 321 values
+INFO: Step 13, time 37022.9, S_Mises, 1 components, 321 values
+INFO: Step 13, time 37022.9, S_Principal, 4 components, 321 values
+INFO: Step 13, time 37022.9, E, 6 components, 321 values
+INFO: Step 13, time 37022.9, E_Mises, 1 components, 321 values
+INFO: Step 13, time 37022.9, E_Principal, 4 components, 321 values
+INFO: Step 13, time 37022.9, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.13.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.13.vtu
+INFO: Step 14, time 37302.0, U, 3 components, 321 values
+INFO: Step 14, time 37302.0, S, 6 components, 321 values
+INFO: Step 14, time 37302.0, S_Mises, 1 components, 321 values
+INFO: Step 14, time 37302.0, S_Principal, 4 components, 321 values
+INFO: Step 14, time 37302.0, E, 6 components, 321 values
+INFO: Step 14, time 37302.0, E_Mises, 1 components, 321 values
+INFO: Step 14, time 37302.0, E_Principal, 4 components, 321 values
+INFO: Step 14, time 37302.0, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.14.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.14.vtu
+INFO: Step 15, time 38917.4, U, 3 components, 321 values
+INFO: Step 15, time 38917.4, S, 6 components, 321 values
+INFO: Step 15, time 38917.4, S_Mises, 1 components, 321 values
+INFO: Step 15, time 38917.4, S_Principal, 4 components, 321 values
+INFO: Step 15, time 38917.4, E, 6 components, 321 values
+INFO: Step 15, time 38917.4, E_Mises, 1 components, 321 values
+INFO: Step 15, time 38917.4, E_Principal, 4 components, 321 values
+INFO: Step 15, time 38917.4, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.15.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.15.vtu
+INFO: Step 16, time 51346.8, U, 3 components, 321 values
+INFO: Step 16, time 51346.8, S, 6 components, 321 values
+INFO: Step 16, time 51346.8, S_Mises, 1 components, 321 values
+INFO: Step 16, time 51346.8, S_Principal, 4 components, 321 values
+INFO: Step 16, time 51346.8, E, 6 components, 321 values
+INFO: Step 16, time 51346.8, E_Mises, 1 components, 321 values
+INFO: Step 16, time 51346.8, E_Principal, 4 components, 321 values
+INFO: Step 16, time 51346.8, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.16.vtk
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.16.vtu
+INFO: Writing Jan_Lukas_modal_dynamic_staticbeam2.pvd
+0m 0.3s
+
+==================================================
+5: other/Jan_Lukas_static_structural.frd
+INFO: Reading Jan_Lukas_static_structural.frd
+INFO: 321 nodes
+INFO: 40 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 321 values
+INFO: Step 1, time 1.0, S, 6 components, 321 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 321 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 321 values
+INFO: Step 1, time 1.0, E, 6 components, 321 values
+INFO: Step 1, time 1.0, E_Mises, 1 components, 321 values
+INFO: Step 1, time 1.0, E_Principal, 4 components, 321 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 321 values
+INFO: Writing Jan_Lukas_static_structural.vtk
+INFO: Writing Jan_Lukas_static_structural.vtu
+0m 0.0s
+
+==================================================
+6: other/John_Mannisto_blade_sector.frd
+INFO: Reading John_Mannisto_blade_sector.frd
+INFO: 1720 nodes
+INFO: 832 cells
+INFO: 15 time increment s
+INFO: Step 1, time 87.1, U, 3 components, 1720 values
+INFO: Step 1, time 87.1, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.01.vtk
+INFO: Writing John_Mannisto_blade_sector.01.vtu
+INFO: Step 3, time 204.1, U, 3 components, 1720 values
+INFO: Step 3, time 204.1, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.02.vtk
+INFO: Writing John_Mannisto_blade_sector.02.vtu
+INFO: Step 5, time 316.1, U, 3 components, 1720 values
+INFO: Step 5, time 316.1, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.03.vtk
+INFO: Writing John_Mannisto_blade_sector.03.vtu
+INFO: Step 6, time 89.2, U, 3 components, 1720 values
+INFO: Step 6, time 89.2, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.04.vtk
+INFO: Writing John_Mannisto_blade_sector.04.vtu
+INFO: Step 8, time 200.5, U, 3 components, 1720 values
+INFO: Step 8, time 200.5, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.05.vtk
+INFO: Writing John_Mannisto_blade_sector.05.vtu
+INFO: Step 10, time 316.1, U, 3 components, 1720 values
+INFO: Step 10, time 316.1, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.06.vtk
+INFO: Writing John_Mannisto_blade_sector.06.vtu
+INFO: Step 11, time 89.3, U, 3 components, 1720 values
+INFO: Step 11, time 89.3, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.07.vtk
+INFO: Writing John_Mannisto_blade_sector.07.vtu
+INFO: Step 13, time 206.2, U, 3 components, 1720 values
+INFO: Step 13, time 206.2, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.08.vtk
+INFO: Writing John_Mannisto_blade_sector.08.vtu
+INFO: Step 15, time 317.5, U, 3 components, 1720 values
+INFO: Step 15, time 317.5, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.09.vtk
+INFO: Writing John_Mannisto_blade_sector.09.vtu
+INFO: Step 16, time 88.5, U, 3 components, 1720 values
+INFO: Step 16, time 88.5, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.10.vtk
+INFO: Writing John_Mannisto_blade_sector.10.vtu
+INFO: Step 18, time 215.5, U, 3 components, 1720 values
+INFO: Step 18, time 215.5, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.11.vtk
+INFO: Writing John_Mannisto_blade_sector.11.vtu
+INFO: Step 20, time 318.4, U, 3 components, 1720 values
+INFO: Step 20, time 318.4, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.12.vtk
+INFO: Writing John_Mannisto_blade_sector.12.vtu
+INFO: Step 21, time 88.2, U, 3 components, 1720 values
+INFO: Step 21, time 88.2, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.13.vtk
+INFO: Writing John_Mannisto_blade_sector.13.vtu
+INFO: Step 23, time 218.8, U, 3 components, 1720 values
+INFO: Step 23, time 218.8, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.14.vtk
+INFO: Writing John_Mannisto_blade_sector.14.vtu
+INFO: Step 25, time 318.6, U, 3 components, 1720 values
+INFO: Step 25, time 318.6, DISPI, 3 components, 1720 values
+INFO: Writing John_Mannisto_blade_sector.15.vtk
+INFO: Writing John_Mannisto_blade_sector.15.vtu
+INFO: Writing John_Mannisto_blade_sector.pvd
+0m 0.3s
+
+==================================================
+7: other/John_Mannisto_buckling_trick.frd
+INFO: Reading John_Mannisto_buckling_trick.frd
+INFO: 542 nodes
+INFO: 80 cells
+INFO: 3 time increment s
+INFO: Step 1, time 1.00e-02, U, 3 components, 542 values
+INFO: Step 1, time 1.00e-02, S, 6 components, 542 values
+INFO: Step 1, time 1.00e-02, S_Mises, 1 components, 542 values
+INFO: Step 1, time 1.00e-02, S_Principal, 4 components, 542 values
+INFO: Step 1, time 1.00e-02, RF, 3 components, 542 values
+INFO: Step 1, time 1.00e-02, ERROR, 1 components, 542 values
+INFO: Writing John_Mannisto_buckling_trick.1.vtk
+INFO: Writing John_Mannisto_buckling_trick.1.vtu
+INFO: Step 2, time 2.00e-02, U, 3 components, 542 values
+INFO: Step 2, time 2.00e-02, S, 6 components, 542 values
+INFO: Step 2, time 2.00e-02, S_Mises, 1 components, 542 values
+INFO: Step 2, time 2.00e-02, S_Principal, 4 components, 542 values
+INFO: Step 2, time 2.00e-02, RF, 3 components, 542 values
+INFO: Step 2, time 2.00e-02, ERROR, 1 components, 542 values
+INFO: Writing John_Mannisto_buckling_trick.2.vtk
+INFO: Writing John_Mannisto_buckling_trick.2.vtu
+INFO: Step 3, time 3.00e-02, U, 3 components, 542 values
+INFO: Step 3, time 3.00e-02, RF, 3 components, 542 values
+INFO: Writing John_Mannisto_buckling_trick.3.vtk
+INFO: Writing John_Mannisto_buckling_trick.3.vtu
+INFO: Writing John_Mannisto_buckling_trick.pvd
+0m 0.0s
+
+==================================================
+8: other/Kaffeeheblerei_hinge.frd
+INFO: Reading Kaffeeheblerei_hinge.frd
+INFO: 378 nodes
+INFO: 160 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 378 values
+INFO: Step 1, time 1.0, S, 6 components, 378 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 378 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 378 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 378 values
+INFO: Writing Kaffeeheblerei_hinge.vtk
+INFO: Writing Kaffeeheblerei_hinge.vtu
+0m 0.0s
+
+==================================================
+9: other/Nidish_Narayanaa_Balaji.frd
+INFO: Reading Nidish_Narayanaa_Balaji.frd
+INFO: 3432 nodes
+INFO: 2560 cells
+INFO: 10 time increment s
+INFO: Step 1, time 721.9, U, 3 components, 3432 values
+INFO: Step 1, time 721.9, S, 6 components, 3432 values
+INFO: Step 1, time 721.9, S_Mises, 1 components, 3432 values
+INFO: Step 1, time 721.9, S_Principal, 4 components, 3432 values
+INFO: Step 1, time 721.9, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.01.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.01.vtu
+INFO: Step 2, time 1405.0, U, 3 components, 3432 values
+INFO: Step 2, time 1405.0, S, 6 components, 3432 values
+INFO: Step 2, time 1405.0, S_Mises, 1 components, 3432 values
+INFO: Step 2, time 1405.0, S_Principal, 4 components, 3432 values
+INFO: Step 2, time 1405.0, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.02.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.02.vtu
+INFO: Step 3, time 4255.6, U, 3 components, 3432 values
+INFO: Step 3, time 4255.6, S, 6 components, 3432 values
+INFO: Step 3, time 4255.6, S_Mises, 1 components, 3432 values
+INFO: Step 3, time 4255.6, S_Principal, 4 components, 3432 values
+INFO: Step 3, time 4255.6, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.03.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.03.vtu
+INFO: Step 4, time 4908.6, U, 3 components, 3432 values
+INFO: Step 4, time 4908.6, S, 6 components, 3432 values
+INFO: Step 4, time 4908.6, S_Mises, 1 components, 3432 values
+INFO: Step 4, time 4908.6, S_Principal, 4 components, 3432 values
+INFO: Step 4, time 4908.6, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.04.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.04.vtu
+INFO: Step 5, time 7617.8, U, 3 components, 3432 values
+INFO: Step 5, time 7617.8, S, 6 components, 3432 values
+INFO: Step 5, time 7617.8, S_Mises, 1 components, 3432 values
+INFO: Step 5, time 7617.8, S_Principal, 4 components, 3432 values
+INFO: Step 5, time 7617.8, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.05.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.05.vtu
+INFO: Step 6, time 10355.9, U, 3 components, 3432 values
+INFO: Step 6, time 10355.9, S, 6 components, 3432 values
+INFO: Step 6, time 10355.9, S_Mises, 1 components, 3432 values
+INFO: Step 6, time 10355.9, S_Principal, 4 components, 3432 values
+INFO: Step 6, time 10355.9, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.06.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.06.vtu
+INFO: Step 7, time 11354.6, U, 3 components, 3432 values
+INFO: Step 7, time 11354.6, S, 6 components, 3432 values
+INFO: Step 7, time 11354.6, S_Mises, 1 components, 3432 values
+INFO: Step 7, time 11354.6, S_Principal, 4 components, 3432 values
+INFO: Step 7, time 11354.6, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.07.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.07.vtu
+INFO: Step 8, time 14874.6, U, 3 components, 3432 values
+INFO: Step 8, time 14874.6, S, 6 components, 3432 values
+INFO: Step 8, time 14874.6, S_Mises, 1 components, 3432 values
+INFO: Step 8, time 14874.6, S_Principal, 4 components, 3432 values
+INFO: Step 8, time 14874.6, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.08.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.08.vtu
+INFO: Step 9, time 17166.5, U, 3 components, 3432 values
+INFO: Step 9, time 17166.5, S, 6 components, 3432 values
+INFO: Step 9, time 17166.5, S_Mises, 1 components, 3432 values
+INFO: Step 9, time 17166.5, S_Principal, 4 components, 3432 values
+INFO: Step 9, time 17166.5, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.09.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.09.vtu
+INFO: Step 10, time 20441.6, U, 3 components, 3432 values
+INFO: Step 10, time 20441.6, S, 6 components, 3432 values
+INFO: Step 10, time 20441.6, S_Mises, 1 components, 3432 values
+INFO: Step 10, time 20441.6, S_Principal, 4 components, 3432 values
+INFO: Step 10, time 20441.6, ERROR, 1 components, 3432 values
+INFO: Writing Nidish_Narayanaa_Balaji.10.vtk
+INFO: Writing Nidish_Narayanaa_Balaji.10.vtu
+INFO: Writing Nidish_Narayanaa_Balaji.pvd
+0m 1.0s
+
+==================================================
+10: other/RingBeam.frd
+INFO: Reading RingBeam.frd
+INFO: 39312 nodes
+INFO: 31104 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 39312 values
+INFO: Step 1, time 1.0, S, 6 components, 39312 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 39312 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 39312 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 39312 values
+INFO: Writing RingBeam.vtk
+INFO: Writing RingBeam.vtu
+0m 1.3s
+
+==================================================
+11: other/Spanner-in.frd
+INFO: Reading Spanner-in.frd
+INFO: 10386 nodes
+INFO: 5099 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 10386 values
+INFO: Step 1, time 1.0, S, 6 components, 10386 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 10386 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 10386 values
+INFO: Step 1, time 1.0, E, 6 components, 10386 values
+INFO: Step 1, time 1.0, E_Mises, 1 components, 10386 values
+INFO: Step 1, time 1.0, E_Principal, 4 components, 10386 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 10386 values
+INFO: Writing Spanner-in.vtk
+INFO: Writing Spanner-in.vtu
+0m 0.5s
+
+==================================================
+12: other/ball.frd
+INFO: Reading ball.frd
+INFO: 4812 nodes
+INFO: 2259 cells
+INFO: 8 time increment s
+INFO: Step 1, time 1.00e-01, U, 3 components, 4812 values
+INFO: Step 1, time 1.00e-01, S, 6 components, 4812 values
+INFO: Step 1, time 1.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 1, time 1.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 1, time 1.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.1.vtk
+INFO: Writing ball.1.vtu
+INFO: Step 2, time 2.00e-01, U, 3 components, 4812 values
+INFO: Step 2, time 2.00e-01, S, 6 components, 4812 values
+INFO: Step 2, time 2.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 2, time 2.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 2, time 2.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.2.vtk
+INFO: Writing ball.2.vtu
+INFO: Step 3, time 3.00e-01, U, 3 components, 4812 values
+INFO: Step 3, time 3.00e-01, S, 6 components, 4812 values
+INFO: Step 3, time 3.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 3, time 3.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 3, time 3.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.3.vtk
+INFO: Writing ball.3.vtu
+INFO: Step 4, time 4.00e-01, U, 3 components, 4812 values
+INFO: Step 4, time 4.00e-01, S, 6 components, 4812 values
+INFO: Step 4, time 4.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 4, time 4.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 4, time 4.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.4.vtk
+INFO: Writing ball.4.vtu
+INFO: Step 5, time 5.00e-01, U, 3 components, 4812 values
+INFO: Step 5, time 5.00e-01, S, 6 components, 4812 values
+INFO: Step 5, time 5.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 5, time 5.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 5, time 5.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.5.vtk
+INFO: Writing ball.5.vtu
+INFO: Step 6, time 6.00e-01, U, 3 components, 4812 values
+INFO: Step 6, time 6.00e-01, S, 6 components, 4812 values
+INFO: Step 6, time 6.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 6, time 6.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 6, time 6.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.6.vtk
+INFO: Writing ball.6.vtu
+INFO: Step 7, time 7.00e-01, U, 3 components, 4812 values
+INFO: Step 7, time 7.00e-01, S, 6 components, 4812 values
+INFO: Step 7, time 7.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 7, time 7.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 7, time 7.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.7.vtk
+INFO: Writing ball.7.vtu
+INFO: Step 8, time 8.00e-01, U, 3 components, 4812 values
+INFO: Step 8, time 8.00e-01, S, 6 components, 4812 values
+INFO: Step 8, time 8.00e-01, S_Mises, 1 components, 4812 values
+INFO: Step 8, time 8.00e-01, S_Principal, 4 components, 4812 values
+INFO: Step 8, time 8.00e-01, ERROR, 1 components, 4812 values
+INFO: Writing ball.8.vtk
+INFO: Writing ball.8.vtu
+INFO: Writing ball.pvd
+0m 1.1s
+
+==================================================
+13: other/contact2e.frd
+INFO: Reading contact2e.frd
+INFO: 522 nodes
+INFO: 64 cells
+INFO: 87 time increment s
+INFO: Step 1, time 1.47e-06, U, 3 components, 522 values
+INFO: Writing contact2e.01.vtk
+INFO: Writing contact2e.01.vtu
+INFO: Step 2, time 2.94e-06, U, 3 components, 522 values
+INFO: Writing contact2e.02.vtk
+INFO: Writing contact2e.02.vtu
+INFO: Step 3, time 4.41e-06, U, 3 components, 522 values
+INFO: Writing contact2e.03.vtk
+INFO: Writing contact2e.03.vtu
+INFO: Step 4, time 5.88e-06, U, 3 components, 522 values
+INFO: Writing contact2e.04.vtk
+INFO: Writing contact2e.04.vtu
+INFO: Step 5, time 7.35e-06, U, 3 components, 522 values
+INFO: Writing contact2e.05.vtk
+INFO: Writing contact2e.05.vtu
+INFO: Step 6, time 8.82e-06, U, 3 components, 522 values
+INFO: Writing contact2e.06.vtk
+INFO: Writing contact2e.06.vtu
+INFO: Step 7, time 1.03e-05, U, 3 components, 522 values
+INFO: Writing contact2e.07.vtk
+INFO: Writing contact2e.07.vtu
+INFO: Step 8, time 1.18e-05, U, 3 components, 522 values
+INFO: Writing contact2e.08.vtk
+INFO: Writing contact2e.08.vtu
+INFO: Step 9, time 1.32e-05, U, 3 components, 522 values
+INFO: Writing contact2e.09.vtk
+INFO: Writing contact2e.09.vtu
+INFO: Step 10, time 1.47e-05, U, 3 components, 522 values
+INFO: Writing contact2e.10.vtk
+INFO: Writing contact2e.10.vtu
+INFO: Step 11, time 1.62e-05, U, 3 components, 522 values
+INFO: Writing contact2e.11.vtk
+INFO: Writing contact2e.11.vtu
+INFO: Step 12, time 1.76e-05, U, 3 components, 522 values
+INFO: Writing contact2e.12.vtk
+INFO: Writing contact2e.12.vtu
+INFO: Step 13, time 1.91e-05, U, 3 components, 522 values
+INFO: Writing contact2e.13.vtk
+INFO: Writing contact2e.13.vtu
+INFO: Step 14, time 2.06e-05, U, 3 components, 522 values
+INFO: Writing contact2e.14.vtk
+INFO: Writing contact2e.14.vtu
+INFO: Step 15, time 2.20e-05, U, 3 components, 522 values
+INFO: Writing contact2e.15.vtk
+INFO: Writing contact2e.15.vtu
+INFO: Step 16, time 2.35e-05, U, 3 components, 522 values
+INFO: Writing contact2e.16.vtk
+INFO: Writing contact2e.16.vtu
+INFO: Step 17, time 2.50e-05, U, 3 components, 522 values
+INFO: Writing contact2e.17.vtk
+INFO: Writing contact2e.17.vtu
+INFO: Step 18, time 2.65e-05, U, 3 components, 522 values
+INFO: Writing contact2e.18.vtk
+INFO: Writing contact2e.18.vtu
+INFO: Step 19, time 2.69e-05, U, 3 components, 522 values
+INFO: Writing contact2e.19.vtk
+INFO: Writing contact2e.19.vtu
+INFO: Step 20, time 2.73e-05, U, 3 components, 522 values
+INFO: Writing contact2e.20.vtk
+INFO: Writing contact2e.20.vtu
+INFO: Step 21, time 2.77e-05, U, 3 components, 522 values
+INFO: Writing contact2e.21.vtk
+INFO: Writing contact2e.21.vtu
+INFO: Step 22, time 2.81e-05, U, 3 components, 522 values
+INFO: Writing contact2e.22.vtk
+INFO: Writing contact2e.22.vtu
+INFO: Step 23, time 2.85e-05, U, 3 components, 522 values
+INFO: Writing contact2e.23.vtk
+INFO: Writing contact2e.23.vtu
+INFO: Step 24, time 2.89e-05, U, 3 components, 522 values
+INFO: Writing contact2e.24.vtk
+INFO: Writing contact2e.24.vtu
+INFO: Step 25, time 2.92e-05, U, 3 components, 522 values
+INFO: Writing contact2e.25.vtk
+INFO: Writing contact2e.25.vtu
+INFO: Step 26, time 2.99e-05, U, 3 components, 522 values
+INFO: Writing contact2e.26.vtk
+INFO: Writing contact2e.26.vtu
+INFO: Step 27, time 3.14e-05, U, 3 components, 522 values
+INFO: Writing contact2e.27.vtk
+INFO: Writing contact2e.27.vtu
+INFO: Step 28, time 3.29e-05, U, 3 components, 522 values
+INFO: Writing contact2e.28.vtk
+INFO: Writing contact2e.28.vtu
+INFO: Step 29, time 3.39e-05, U, 3 components, 522 values
+INFO: Writing contact2e.29.vtk
+INFO: Writing contact2e.29.vtu
+INFO: Step 30, time 3.43e-05, U, 3 components, 522 values
+INFO: Writing contact2e.30.vtk
+INFO: Writing contact2e.30.vtu
+INFO: Step 31, time 3.47e-05, U, 3 components, 522 values
+INFO: Writing contact2e.31.vtk
+INFO: Writing contact2e.31.vtu
+INFO: Step 32, time 3.51e-05, U, 3 components, 522 values
+INFO: Writing contact2e.32.vtk
+INFO: Writing contact2e.32.vtu
+INFO: Step 33, time 3.55e-05, U, 3 components, 522 values
+INFO: Writing contact2e.33.vtk
+INFO: Writing contact2e.33.vtu
+INFO: Step 34, time 3.59e-05, U, 3 components, 522 values
+INFO: Writing contact2e.34.vtk
+INFO: Writing contact2e.34.vtu
+INFO: Step 35, time 3.63e-05, U, 3 components, 522 values
+INFO: Writing contact2e.35.vtk
+INFO: Writing contact2e.35.vtu
+INFO: Step 36, time 3.67e-05, U, 3 components, 522 values
+INFO: Writing contact2e.36.vtk
+INFO: Writing contact2e.36.vtu
+INFO: Step 37, time 3.75e-05, U, 3 components, 522 values
+INFO: Writing contact2e.37.vtk
+INFO: Writing contact2e.37.vtu
+INFO: Step 38, time 3.90e-05, U, 3 components, 522 values
+INFO: Writing contact2e.38.vtk
+INFO: Writing contact2e.38.vtu
+INFO: Step 39, time 4.04e-05, U, 3 components, 522 values
+INFO: Writing contact2e.39.vtk
+INFO: Writing contact2e.39.vtu
+INFO: Step 40, time 4.19e-05, U, 3 components, 522 values
+INFO: Writing contact2e.40.vtk
+INFO: Writing contact2e.40.vtu
+INFO: Step 41, time 4.34e-05, U, 3 components, 522 values
+INFO: Writing contact2e.41.vtk
+INFO: Writing contact2e.41.vtu
+INFO: Step 42, time 4.49e-05, U, 3 components, 522 values
+INFO: Writing contact2e.42.vtk
+INFO: Writing contact2e.42.vtu
+INFO: Step 43, time 4.63e-05, U, 3 components, 522 values
+INFO: Writing contact2e.43.vtk
+INFO: Writing contact2e.43.vtu
+INFO: Step 44, time 4.78e-05, U, 3 components, 522 values
+INFO: Writing contact2e.44.vtk
+INFO: Writing contact2e.44.vtu
+INFO: Step 45, time 4.93e-05, U, 3 components, 522 values
+INFO: Writing contact2e.45.vtk
+INFO: Writing contact2e.45.vtu
+INFO: Step 46, time 5.07e-05, U, 3 components, 522 values
+INFO: Writing contact2e.46.vtk
+INFO: Writing contact2e.46.vtu
+INFO: Step 47, time 5.22e-05, U, 3 components, 522 values
+INFO: Writing contact2e.47.vtk
+INFO: Writing contact2e.47.vtu
+INFO: Step 48, time 5.37e-05, U, 3 components, 522 values
+INFO: Writing contact2e.48.vtk
+INFO: Writing contact2e.48.vtu
+INFO: Step 49, time 5.51e-05, U, 3 components, 522 values
+INFO: Writing contact2e.49.vtk
+INFO: Writing contact2e.49.vtu
+INFO: Step 50, time 5.66e-05, U, 3 components, 522 values
+INFO: Writing contact2e.50.vtk
+INFO: Writing contact2e.50.vtu
+INFO: Step 51, time 5.81e-05, U, 3 components, 522 values
+INFO: Writing contact2e.51.vtk
+INFO: Writing contact2e.51.vtu
+INFO: Step 52, time 5.95e-05, U, 3 components, 522 values
+INFO: Writing contact2e.52.vtk
+INFO: Writing contact2e.52.vtu
+INFO: Step 53, time 6.10e-05, U, 3 components, 522 values
+INFO: Writing contact2e.53.vtk
+INFO: Writing contact2e.53.vtu
+INFO: Step 54, time 6.25e-05, U, 3 components, 522 values
+INFO: Writing contact2e.54.vtk
+INFO: Writing contact2e.54.vtu
+INFO: Step 55, time 6.40e-05, U, 3 components, 522 values
+INFO: Writing contact2e.55.vtk
+INFO: Writing contact2e.55.vtu
+INFO: Step 56, time 6.54e-05, U, 3 components, 522 values
+INFO: Writing contact2e.56.vtk
+INFO: Writing contact2e.56.vtu
+INFO: Step 57, time 6.69e-05, U, 3 components, 522 values
+INFO: Writing contact2e.57.vtk
+INFO: Writing contact2e.57.vtu
+INFO: Step 58, time 6.84e-05, U, 3 components, 522 values
+INFO: Writing contact2e.58.vtk
+INFO: Writing contact2e.58.vtu
+INFO: Step 59, time 6.98e-05, U, 3 components, 522 values
+INFO: Writing contact2e.59.vtk
+INFO: Writing contact2e.59.vtu
+INFO: Step 60, time 7.13e-05, U, 3 components, 522 values
+INFO: Writing contact2e.60.vtk
+INFO: Writing contact2e.60.vtu
+INFO: Step 61, time 7.28e-05, U, 3 components, 522 values
+INFO: Writing contact2e.61.vtk
+INFO: Writing contact2e.61.vtu
+INFO: Step 62, time 7.42e-05, U, 3 components, 522 values
+INFO: Writing contact2e.62.vtk
+INFO: Writing contact2e.62.vtu
+INFO: Step 63, time 7.57e-05, U, 3 components, 522 values
+INFO: Writing contact2e.63.vtk
+INFO: Writing contact2e.63.vtu
+INFO: Step 64, time 7.72e-05, U, 3 components, 522 values
+INFO: Writing contact2e.64.vtk
+INFO: Writing contact2e.64.vtu
+INFO: Step 65, time 7.87e-05, U, 3 components, 522 values
+INFO: Writing contact2e.65.vtk
+INFO: Writing contact2e.65.vtu
+INFO: Step 66, time 8.01e-05, U, 3 components, 522 values
+INFO: Writing contact2e.66.vtk
+INFO: Writing contact2e.66.vtu
+INFO: Step 67, time 8.16e-05, U, 3 components, 522 values
+INFO: Writing contact2e.67.vtk
+INFO: Writing contact2e.67.vtu
+INFO: Step 68, time 8.31e-05, U, 3 components, 522 values
+INFO: Writing contact2e.68.vtk
+INFO: Writing contact2e.68.vtu
+INFO: Step 69, time 8.45e-05, U, 3 components, 522 values
+INFO: Writing contact2e.69.vtk
+INFO: Writing contact2e.69.vtu
+INFO: Step 70, time 8.60e-05, U, 3 components, 522 values
+INFO: Writing contact2e.70.vtk
+INFO: Writing contact2e.70.vtu
+INFO: Step 71, time 8.75e-05, U, 3 components, 522 values
+INFO: Writing contact2e.71.vtk
+INFO: Writing contact2e.71.vtu
+INFO: Step 72, time 8.89e-05, U, 3 components, 522 values
+INFO: Writing contact2e.72.vtk
+INFO: Writing contact2e.72.vtu
+INFO: Step 73, time 9.04e-05, U, 3 components, 522 values
+INFO: Writing contact2e.73.vtk
+INFO: Writing contact2e.73.vtu
+INFO: Step 74, time 9.19e-05, U, 3 components, 522 values
+INFO: Writing contact2e.74.vtk
+INFO: Writing contact2e.74.vtu
+INFO: Step 75, time 9.23e-05, U, 3 components, 522 values
+INFO: Writing contact2e.75.vtk
+INFO: Writing contact2e.75.vtu
+INFO: Step 76, time 9.26e-05, U, 3 components, 522 values
+INFO: Writing contact2e.76.vtk
+INFO: Writing contact2e.76.vtu
+INFO: Step 77, time 9.30e-05, U, 3 components, 522 values
+INFO: Writing contact2e.77.vtk
+INFO: Writing contact2e.77.vtu
+INFO: Step 78, time 9.33e-05, U, 3 components, 522 values
+INFO: Writing contact2e.78.vtk
+INFO: Writing contact2e.78.vtu
+INFO: Step 79, time 9.37e-05, U, 3 components, 522 values
+INFO: Writing contact2e.79.vtk
+INFO: Writing contact2e.79.vtu
+INFO: Step 80, time 9.40e-05, U, 3 components, 522 values
+INFO: Writing contact2e.80.vtk
+INFO: Writing contact2e.80.vtu
+INFO: Step 81, time 9.44e-05, U, 3 components, 522 values
+INFO: Writing contact2e.81.vtk
+INFO: Writing contact2e.81.vtu
+INFO: Step 82, time 9.47e-05, U, 3 components, 522 values
+INFO: Writing contact2e.82.vtk
+INFO: Writing contact2e.82.vtu
+INFO: Step 83, time 9.51e-05, U, 3 components, 522 values
+INFO: Writing contact2e.83.vtk
+INFO: Writing contact2e.83.vtu
+INFO: Step 84, time 9.58e-05, U, 3 components, 522 values
+INFO: Writing contact2e.84.vtk
+INFO: Writing contact2e.84.vtu
+INFO: Step 85, time 9.73e-05, U, 3 components, 522 values
+INFO: Writing contact2e.85.vtk
+INFO: Writing contact2e.85.vtu
+INFO: Step 86, time 9.87e-05, U, 3 components, 522 values
+INFO: Writing contact2e.86.vtk
+INFO: Writing contact2e.86.vtu
+INFO: Step 87, time 1.00e-04, U, 3 components, 522 values
+INFO: Writing contact2e.87.vtk
+INFO: Writing contact2e.87.vtu
+INFO: Writing contact2e.pvd
+0m 0.4s
+
+==================================================
+14: other/contact2i.frd
+INFO: Reading contact2i.frd
+INFO: 522 nodes
+INFO: 64 cells
+INFO: 58 time increment s
+INFO: Step 1, time 2.50e-05, U, 3 components, 522 values
+INFO: Writing contact2i.01.vtk
+INFO: Writing contact2i.01.vtu
+INFO: Step 2, time 3.13e-05, U, 3 components, 522 values
+INFO: Writing contact2i.02.vtk
+INFO: Writing contact2i.02.vtu
+INFO: Step 3, time 3.75e-05, U, 3 components, 522 values
+INFO: Writing contact2i.03.vtk
+INFO: Writing contact2i.03.vtu
+INFO: Step 4, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.04.vtk
+INFO: Writing contact2i.04.vtu
+INFO: Step 5, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.05.vtk
+INFO: Writing contact2i.05.vtu
+INFO: Step 6, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.06.vtk
+INFO: Writing contact2i.06.vtu
+INFO: Step 7, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.07.vtk
+INFO: Writing contact2i.07.vtu
+INFO: Step 8, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.08.vtk
+INFO: Writing contact2i.08.vtu
+INFO: Step 9, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.09.vtk
+INFO: Writing contact2i.09.vtu
+INFO: Step 10, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.10.vtk
+INFO: Writing contact2i.10.vtu
+INFO: Step 11, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.11.vtk
+INFO: Writing contact2i.11.vtu
+INFO: Step 12, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.12.vtk
+INFO: Writing contact2i.12.vtu
+INFO: Step 13, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.13.vtk
+INFO: Writing contact2i.13.vtu
+INFO: Step 14, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.14.vtk
+INFO: Writing contact2i.14.vtu
+INFO: Step 15, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.15.vtk
+INFO: Writing contact2i.15.vtu
+INFO: Step 16, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.16.vtk
+INFO: Writing contact2i.16.vtu
+INFO: Step 17, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.17.vtk
+INFO: Writing contact2i.17.vtu
+INFO: Step 18, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.18.vtk
+INFO: Writing contact2i.18.vtu
+INFO: Step 19, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.19.vtk
+INFO: Writing contact2i.19.vtu
+INFO: Step 20, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.20.vtk
+INFO: Writing contact2i.20.vtu
+INFO: Step 21, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.21.vtk
+INFO: Writing contact2i.21.vtu
+INFO: Step 22, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.22.vtk
+INFO: Writing contact2i.22.vtu
+INFO: Step 23, time 4.37e-05, U, 3 components, 522 values
+INFO: Writing contact2i.23.vtk
+INFO: Writing contact2i.23.vtu
+INFO: Step 24, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.24.vtk
+INFO: Writing contact2i.24.vtu
+INFO: Step 25, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.25.vtk
+INFO: Writing contact2i.25.vtu
+INFO: Step 26, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.26.vtk
+INFO: Writing contact2i.26.vtu
+INFO: Step 27, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.27.vtk
+INFO: Writing contact2i.27.vtu
+INFO: Step 28, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.28.vtk
+INFO: Writing contact2i.28.vtu
+INFO: Step 29, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.29.vtk
+INFO: Writing contact2i.29.vtu
+INFO: Step 30, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.30.vtk
+INFO: Writing contact2i.30.vtu
+INFO: Step 31, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.31.vtk
+INFO: Writing contact2i.31.vtu
+INFO: Step 32, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.32.vtk
+INFO: Writing contact2i.32.vtu
+INFO: Step 33, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.33.vtk
+INFO: Writing contact2i.33.vtu
+INFO: Step 34, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.34.vtk
+INFO: Writing contact2i.34.vtu
+INFO: Step 35, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.35.vtk
+INFO: Writing contact2i.35.vtu
+INFO: Step 36, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.36.vtk
+INFO: Writing contact2i.36.vtu
+INFO: Step 37, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.37.vtk
+INFO: Writing contact2i.37.vtu
+INFO: Step 38, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.38.vtk
+INFO: Writing contact2i.38.vtu
+INFO: Step 39, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.39.vtk
+INFO: Writing contact2i.39.vtu
+INFO: Step 40, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.40.vtk
+INFO: Writing contact2i.40.vtu
+INFO: Step 41, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.41.vtk
+INFO: Writing contact2i.41.vtu
+INFO: Step 42, time 4.38e-05, U, 3 components, 522 values
+INFO: Writing contact2i.42.vtk
+INFO: Writing contact2i.42.vtu
+INFO: Step 43, time 4.39e-05, U, 3 components, 522 values
+INFO: Writing contact2i.43.vtk
+INFO: Writing contact2i.43.vtu
+INFO: Step 44, time 4.40e-05, U, 3 components, 522 values
+INFO: Writing contact2i.44.vtk
+INFO: Writing contact2i.44.vtu
+INFO: Step 45, time 4.41e-05, U, 3 components, 522 values
+INFO: Writing contact2i.45.vtk
+INFO: Writing contact2i.45.vtu
+INFO: Step 46, time 4.42e-05, U, 3 components, 522 values
+INFO: Writing contact2i.46.vtk
+INFO: Writing contact2i.46.vtu
+INFO: Step 47, time 4.45e-05, U, 3 components, 522 values
+INFO: Writing contact2i.47.vtk
+INFO: Writing contact2i.47.vtu
+INFO: Step 48, time 4.49e-05, U, 3 components, 522 values
+INFO: Writing contact2i.48.vtk
+INFO: Writing contact2i.48.vtu
+INFO: Step 49, time 4.54e-05, U, 3 components, 522 values
+INFO: Writing contact2i.49.vtk
+INFO: Writing contact2i.49.vtu
+INFO: Step 50, time 4.63e-05, U, 3 components, 522 values
+INFO: Writing contact2i.50.vtk
+INFO: Writing contact2i.50.vtu
+INFO: Step 51, time 4.75e-05, U, 3 components, 522 values
+INFO: Writing contact2i.51.vtk
+INFO: Writing contact2i.51.vtu
+INFO: Step 52, time 4.94e-05, U, 3 components, 522 values
+INFO: Writing contact2i.52.vtk
+INFO: Writing contact2i.52.vtu
+INFO: Step 53, time 5.23e-05, U, 3 components, 522 values
+INFO: Writing contact2i.53.vtk
+INFO: Writing contact2i.53.vtu
+INFO: Step 54, time 5.65e-05, U, 3 components, 522 values
+INFO: Writing contact2i.54.vtk
+INFO: Writing contact2i.54.vtu
+INFO: Step 55, time 6.29e-05, U, 3 components, 522 values
+INFO: Writing contact2i.55.vtk
+INFO: Writing contact2i.55.vtu
+INFO: Step 56, time 7.24e-05, U, 3 components, 522 values
+INFO: Writing contact2i.56.vtk
+INFO: Writing contact2i.56.vtu
+INFO: Step 57, time 8.68e-05, U, 3 components, 522 values
+INFO: Writing contact2i.57.vtk
+INFO: Writing contact2i.57.vtu
+INFO: Step 58, time 1.00e-04, U, 3 components, 522 values
+INFO: Writing contact2i.58.vtk
+INFO: Writing contact2i.58.vtu
+INFO: Writing contact2i.pvd
+0m 0.3s
+
+==================================================
+15: other/dichtstoff_2_HE8.frd
+INFO: Reading dichtstoff_2_HE8.frd
+INFO: 12 nodes
+INFO: 2 cells
+INFO: 1 time increment
+INFO: Step 1, time 1.0, U, 3 components, 12 values
+INFO: Step 1, time 1.0, S, 6 components, 12 values
+INFO: Step 1, time 1.0, S_Mises, 1 components, 12 values
+INFO: Step 1, time 1.0, S_Principal, 4 components, 12 values
+INFO: Step 1, time 1.0, ERROR, 1 components, 12 values
+INFO: Writing dichtstoff_2_HE8.vtk
+INFO: Writing dichtstoff_2_HE8.vtu
+0m 0.0s
+
+==================================================
+16: other/hueeber1.frd
+INFO: Reading hueeber1.frd
+INFO: 17524 nodes
+INFO: 8500 cells
+WARNING: No time increments!
+INFO: Writing hueeber1.vtk
+INFO: Writing hueeber1.vtu
+0m 0.1s
+
+==================================================
+17: other/induction.frd
+INFO: Reading induction.frd
+INFO: 3473 nodes
+INFO: 612 cells
+INFO: 2 time increment s
+INFO: Step 1, time 0.00e+00, ELPOT, 1 components, 3473 values
+INFO: Step 1, time 0.00e+00, CURR, 3 components, 3473 values
+INFO: Writing induction.1.vtk
+INFO: Writing induction.1.vtu
+INFO: Step 2, time 1.0, EMFB, 3 components, 3473 values
+INFO: Writing induction.2.vtk
+INFO: Writing induction.2.vtu
+INFO: Writing induction.pvd
+0m 0.1s
+
+Total 0m 6.2s

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,7 +32,7 @@ from ccx2paraview.common import Converter
 # pylint: enable=wrong-import-position
 
 # Logging Handler
-LH = None
+logging_handler = None # pylint: disable=invalid-name
 
 def clean_cache(folder=None):
     """Recursively delete cached files in all subfolders."""
@@ -90,7 +90,7 @@ def test_my_parser_in(folder):
     """Convert calculation results."""
     for counter, file_path in enumerate(scan_all_files_in(folder, '.frd')):
         relpath = os.path.relpath(file_path, start=folder)
-        LH.println('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
+        logging_handler.println('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
         test_my_single_file(file_path)
 
 
@@ -103,7 +103,7 @@ def test_my_single_file(file_path):
         ccx2paraview = Converter(file_path, ['vtk', 'vtu'])
         ccx2paraview.run()
         delta = time.perf_counter() - start
-        LH.println(get_time_delta(delta))
+        logging_handler.println(get_time_delta(delta))
     except:
         logging.error(traceback.format_exc())
 
@@ -111,7 +111,7 @@ def test_my_single_file(file_path):
 def test_freecad_parser_in(folder):
     for counter, file_path in enumerate(scan_all_files_in(folder, '.frd')):
         relpath = os.path.relpath(file_path, start=folder)
-        LH.println('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
+        logging_handler.println('\n{}\n{}: {}'.format('='*50, counter+1, relpath))
         test_freecad_single_file(file_path)
 
 
@@ -121,7 +121,7 @@ def test_freecad_single_file(file_path):
         start = time.perf_counter()
         read_frd_result(file_path)
         delta = time.perf_counter() - start
-        LH.println(get_time_delta(delta))
+        logging_handler.println(get_time_delta(delta))
     except:
         logging.error(traceback.format_exc())
 
@@ -135,22 +135,22 @@ def test_binary_in(folder):
             command = './bin/ccx2paraview'
         relpath = os.path.relpath(file_path, start=folder)
         for fmt in ['vtk', 'vtu']:
-            LH.println('\n{}\n{}: {}'.format('='*50, counter, relpath))
+            logging_handler.println('\n{}\n{}: {}'.format('='*50, counter, relpath))
             cmd = [command, file_path, fmt]
             try:
                 process = subprocess.Popen(cmd,
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT)
-                LH.read_and_log(process.stdout)
+                logging_handler.read_and_log(process.stdout)
             except:
                 logging.error(traceback.format_exc())
-        LH.stop_read_and_log()
+        logging_handler.stop_read_and_log()
 
 def test_numpy():
     import numpy as np
     a = np.zeros([10, 2])
-    LH.println(a[:, 0])
+    logging_handler.println(a[:, 0])
 
 
 # def test_NodalPointCoordinateBlock2():
@@ -165,14 +165,14 @@ def test_numpy():
 
 def test_lin_indexes():
     line = ' -1         1-6.64251E-02-6.64250E-02-1.54991E-01-1.06122E-08-1.43067E-02 3.02626E-02'
-    LH.println(line[:5])
-    LH.println(line[5:13])
-    LH.println(line[13:25])
-    LH.println(line[25:37])
-    LH.println(line[37:49])
-    LH.println(line[49:61])
-    LH.println(line[61:73])
-    LH.println(line[73:85])
+    logging_handler.println(line[:5])
+    logging_handler.println(line[5:13])
+    logging_handler.println(line[13:25])
+    logging_handler.println(line[25:37])
+    logging_handler.println(line[37:49])
+    logging_handler.println(line[49:61])
+    logging_handler.println(line[61:73])
+    logging_handler.println(line[73:85])
 
 
 # Run
@@ -188,25 +188,25 @@ if __name__ == '__main__':
     log_file = os.path.dirname(log_file)
     log_file = os.path.join(log_file, 'test.log')
 
+    # Prepare logging
+    logging_handler = LoggingHandler(log_file)
+    logging.getLogger().addHandler(logging_handler)
+    logging.getLogger().setLevel(logging.DEBUG)
+    logging_handler.println('CONVERTER TEST')
+    logging_handler.println(' ')
+
     # test_numpy()
     # test_NodalPointCoordinateBlock2()
     # test_lin_indexes()
     # raise SystemExit()
 
-    # Prepare logging
-    LH = LoggingHandler(log_file)
-    logging.getLogger().addHandler(LH)
-    logging.getLogger().setLevel(logging.DEBUG)
-    LH.println('CONVERTER TEST')
-    LH.println(' ')
-
     # test_freecad_parser_in(d)
     # test_freecad_single_file(d + '/other/Sergio_Pluchinsky_PLASTIC_2ND_ORDER.frd_')
 
-    # test_my_parser_in(d)
+    test_my_parser_in(d)
     # test_my_single_file(d + '/other/Sergio_Pluchinsky_PLASTIC_2ND_ORDER.frd_')
     # test_my_single_file(d + '/other/Jan_Lukas_modal_dynamic_beammodal.frd')
-    test_my_single_file(d + '/other/John_Mannisto_blade_sector.frd')
+    # test_my_single_file(d + '/other/John_Mannisto_blade_sector.frd')
     # test_my_single_file(d + '/other/Jan_Lukas_static_structural.frd')
     # test_my_single_file(d + '/other/Ihor_Mirzov_baffle_2D.frd')
     # test_my_single_file(d + '/other/CubeTie/CubeTie.frd')
@@ -219,8 +219,8 @@ if __name__ == '__main__':
     # test_my_single_file(d + '/mkraska/Test/BeamSections/Refs/u1General.frd')
 
     delta = time.perf_counter() - start
-    LH.println(' ')
-    LH.println('Total', get_time_delta(delta))
-    logging.getLogger().removeHandler(LH)
-    LH.stop_read_and_log()
+    logging_handler.println(' ')
+    logging_handler.println('Total', get_time_delta(delta))
+    logging.getLogger().removeHandler(logging_handler)
+    logging_handler.stop_read_and_log()
     clean_cache()


### PR DESCRIPTION
@fsimonis Thanks for testing and giving the input! 
Adding:
```
[project.optional-dependencies]
VTK = [ "vtk" ]
```
to pyproject.toml did the trick. Once being released you can install ccx2paraview (installing vtk alongside) with:
```
pip install 'ccx2paraview[VTK]'
pipx install 'ccx2paraview[VTK]' 
```
for testing right now:
```
pip install 'ccx2paraview[VTK] @ git+https://github.com/soylentOrange/ccx2paraview.git@prepare-3.2.0-release'
pipx install 'ccx2paraview[VTK] @ git+https://github.com/soylentOrange/ccx2paraview.git@prepare-3.2.0-release' --python 3.12
```
I tested the fork with pip, pipx and conda, with and without vtk previously installed... seems to work fine on my machine.


@imirzov  & @fsimonis  yes, I think it's worth a new release (now): 3.2.0
After this PR is merged, the release could be published.

In my opinion, the list of improvements is:

* ~~Added vtkhdf writer~~ (was a proof of concept that's not in the code anymore, as it's purely relying on paraview)
* Fix syntax warning invalid escape sequence
* Made the development version installable by pip
* Add alias scripts for converting to formats
* Add PyPi publishing workflow
* Turned into installable package
* Improvements in von Mises and principal stress calculations
* streamline import of Converter (i.e. `from ccx2paraview import Converter`)
* fix broken pvd-file (missing '.' in '.vtu')
* added description in readme: how to convert to a vtkhdf-file
* added Exception message indicating missing vtk-dependency


BR,
Robert